### PR TITLE
added jenkins slave elcipse loc to cmdlinecompile

### DIFF
--- a/scripts/dockerfile-slave-eclipse
+++ b/scripts/dockerfile-slave-eclipse
@@ -1,0 +1,9 @@
+FROM lnarmour/parric:jenkins-slave-eclipse
+
+USER root
+
+RUN apt-get install -y libboost-all-dev
+
+USER jenkins
+
+ENV DISPLAY=:1

--- a/scripts/slave.sh
+++ b/scripts/slave.sh
@@ -12,13 +12,16 @@ docker run \
   --network jenkins-nw \
   --name slave \
   -d \
-  lnarmour/parric:jenkins-slave \
+  lnarmour/parric:jenkins-slave-eclipse-1.0 \
   -url http://jenkins:8080 \
   -workDir "/home/jenkins/slave" \
   $secret \
   slave
 
-sleep 3
+sleep 10
+
+docker exec -d slave Xvfb :1 -screen 0 1024x768x24
+docker exec -d slave /home/jenkins/eclipse/eclimd -b
 
 if [[ -n $(docker ps -f name=slave -q) ]]; then
    printf "SUCCESS : Created 'slave' successfully.\n"

--- a/tests/jenkinsfile
+++ b/tests/jenkinsfile
@@ -16,5 +16,10 @@ pipeline {
 	}
     }
 
+    post {
+        always {
+            cleanWs()
+        }
+    }
 
 }

--- a/ttmm/alphaz_stuff/cmdlinecompile.sh
+++ b/ttmm/alphaz_stuff/cmdlinecompile.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-ECLIPSE=/s/chopin/e/proj/AlphaZ/BinTree/eclipse-alphaz-bundle/eclipse/eclipse
+# if this is running in the docker 'slave' container then eclipse will be located at /home/jenkins/eclipse/
+if [[ -e /home/jenkins/eclipse/eclipse ]];
+then
+    ECLIPSE=/home/jenkins/eclipse/eclipse
+else
+    ECLIPSE=/s/chopin/e/proj/AlphaZ/BinTree/eclipse-alphaz-bundle/eclipse/eclipse
+fi
+
 SCRIPT=TMMScript.cs
 WORKSPACE=./..
 


### PR DESCRIPTION
I added the location of eclipse inside the jenkins slave container.  Now these checks can run inside the slave container.

I also installed the boost dev libraries inside the slave container so that we can actually use them.