### PR TITLE
Added a script that performs a binary search on the tile size space

### DIFF
--- a/scripts/search_block_space.sh
+++ b/scripts/search_block_space.sh
@@ -12,7 +12,7 @@ let "b3 = $N / 2"
 let "step = $N / 4"
 
 cd ttmm/alphaz_stuff/out
-for iterations in {1..$2}
+for ((iterations=1;iterations<=$2;iterations++))
 do
 	for ts1 in {0..1}
 	do

--- a/scripts/search_block_space.sh
+++ b/scripts/search_block_space.sh
@@ -17,19 +17,52 @@ lower_bound3=0
 let "mid3 = $upper_bound3 - $lower_bound3"
 let "mid3 = $mid3 / 2"
 
+b1=-5
+b2=-5
+b3=-5
+
 cd ttmm/alphaz_stuff/out
-for ts1 in {0..1}
+for iterations in {1..6}
 do
-	let "local_1 = ($lower_bound1 + ($mid1/2) + ($ts1 * $mid1))"
-	for ts2 in { 0..1}
+	old_min=$min
+	for ts1 in {0..1}
 	do
-		let "local_2 = ($lower_bound2 + ($mid2/2) + ($ts2 * $mid2))"
-		for ts3 in {0..1}
+		let "local_1 = ($lower_bound1 + ($mid1/2) + ($ts1 * $mid1))"
+		for ts2 in {0..1}
 		do
-			let "local_3 = ($lower_bound3 + ($mid3/2) + ($ts3 * $mid3))"
-			time=$(./TTMM $N $local_1 $local_2 $local_3 | grep -E -e "\d+(.\d+)?" -o)
-			if [ $min -gt $time ]
-			then
-				min=$time
-				let "upper_bound1 = $local_1 + ( $mid1 /  2)"	
-				let "lower_bound1 = $local_1 - ( $mid1 /  2)"
+			let "local_2 = ($lower_bound2 + ($mid2/2) + ($ts2 * $mid2))"
+			for ts3 in {0..1}
+			do
+				let "local_3 = ($lower_bound3 + ($mid3/2) + ($ts3 * $mid3))"
+				time=$(./TMM $N $local_1 $local_2 $local_3 | grep -E -e "[0-9]+(.[0-9]+)?" -o)	
+				echo "./TMM $N $local_1 $local_2 $local_3 | grep -E -e [0-9]+(.[0-9]+)? -o"
+				if [ $(echo "$min > $time"|bc) -eq 1 ]
+				then
+					min=$time
+					b1=$local_1
+					b2=$local_2
+					b3=$local_3
+				fi
+			done
+		done
+	done
+	if [ $old_min = $min ]
+	then
+		echo "no new min; exiting"
+		exit 0
+	fi
+	
+	let "upper_bound1 = $b1 + ( $mid1 /  2)"	
+	let "lower_bound1 = $b1 - ( $mid1 /  2)"
+	let "upper_bound2 = $b2 + ( $mid2 /  2)"	
+	let "lower_bound2 = $b2 - ( $mid2 /  2)"
+
+	let "upper_bound3 = $b3 + ( $mid3 /  2)"	
+	let "lower_bound3 = $b3 - ( $mid3 /  2)"
+
+	let "mid1 = $mid1 / 2"
+	let "mid2 = $mid2 / 2"
+	let "mid3 = $mid3 / 2"
+
+	echo "best: $min ($b1, $b2, $b3)"
+done

--- a/scripts/search_block_space.sh
+++ b/scripts/search_block_space.sh
@@ -1,14 +1,18 @@
 #! /usr/bin/bash
-
+if [ $# -ne 2 ]
+then
+	echo "usage: $0 <size> <iterations>"
+	exit 1
+fi
 min=100000000
-N=5000
+N=$1
 let "b1 = $N / 2"
 let "b2 = $N / 2"
 let "b3 = $N / 2"
 let "step = $N / 4"
 
 cd ttmm/alphaz_stuff/out
-for iterations in {1..6}
+for iterations in {1..$2}
 do
 	for ts1 in {0..1}
 	do

--- a/scripts/search_block_space.sh
+++ b/scripts/search_block_space.sh
@@ -2,67 +2,40 @@
 
 min=100000000
 N=5000
-upper_bound1=$N
-lower_bound1=0
-let "mid1 = $upper_bound1 - $lower_bound1"
-let "mid1 = $mid1 / 2"
-
-upper_bound2=$N
-lower_bound2=0
-let "mid2 = $upper_bound2 - $lower_bound2"
-let "mid2 = $mid2 / 2"
-
-upper_bound3=$N
-lower_bound3=0
-let "mid3 = $upper_bound3 - $lower_bound3"
-let "mid3 = $mid3 / 2"
-
-b1=-5
-b2=-5
-b3=-5
+let "b1 = $N / 2"
+let "b2 = $N / 2"
+let "b3 = $N / 2"
+let "step = $N / 4"
 
 cd ttmm/alphaz_stuff/out
 for iterations in {1..6}
 do
-	old_min=$min
 	for ts1 in {0..1}
 	do
-		let "local_1 = ($lower_bound1 + ($mid1/2) + ($ts1 * $mid1))"
+		let "local_1 = ($b1 + ( (2 * $ts1) - 1 ) * $step )"
 		for ts2 in {0..1}
 		do
-			let "local_2 = ($lower_bound2 + ($mid2/2) + ($ts2 * $mid2))"
+			let "local_2 = ($b2 + ( (2 * $ts2) - 1 ) * $step )"
 			for ts3 in {0..1}
 			do
-				let "local_3 = ($lower_bound3 + ($mid3/2) + ($ts3 * $mid3))"
+				let "local_3 = ($b3 + ( (2 * $ts3) - 1 ) * $step )"
 				time=$(./TMM $N $local_1 $local_2 $local_3 | grep -E -e "[0-9]+(.[0-9]+)?" -o)	
 				echo "./TMM $N $local_1 $local_2 $local_3 | grep -E -e [0-9]+(.[0-9]+)? -o"
 				if [ $(echo "$min > $time"|bc) -eq 1 ]
 				then
 					min=$time
-					b1=$local_1
-					b2=$local_2
-					b3=$local_3
+					next_b1=$local_1
+					next_b2=$local_2
+					next_b3=$local_3
 				fi
 			done
 		done
 	done
-	if [ $old_min = $min ]
-	then
-		echo "no new min; exiting"
-		exit 0
-	fi
 	
-	let "upper_bound1 = $b1 + ( $mid1 /  2)"	
-	let "lower_bound1 = $b1 - ( $mid1 /  2)"
-	let "upper_bound2 = $b2 + ( $mid2 /  2)"	
-	let "lower_bound2 = $b2 - ( $mid2 /  2)"
-
-	let "upper_bound3 = $b3 + ( $mid3 /  2)"	
-	let "lower_bound3 = $b3 - ( $mid3 /  2)"
-
-	let "mid1 = $mid1 / 2"
-	let "mid2 = $mid2 / 2"
-	let "mid3 = $mid3 / 2"
-
+	let "step = $step / 2"
+	b1=$next_b1
+	b2=$next_b2
+	b3=$next_b3
+	
 	echo "best: $min ($b1, $b2, $b3)"
 done


### PR DESCRIPTION
After running it a couple of times it becomes clear that having a smaller j block is generally better. Script can be easily modified to dump more of its data, allowing a more thorough analysis.