### PR TITLE
enabled invoking from shell using argparse

### DIFF
--- a/results/experiment-0.log
+++ b/results/experiment-0.log
@@ -1,0 +1,2274 @@
+args : {'N': 5000, 'path_prefix': './workspace/parric-ttmm/ttmm/ikj/out', 'keep': [3, 3, 3, 1], 'partitions': [4, 2, 2, 2], 'parent_center': None, 'parent_size': None, 'iterations': 4}
+
+Creating Machine('anchovy')...done.
+Creating Machine('barracuda')...done.
+Creating Machine('blowfish')...done.
+Creating Machine('bonito')...done.
+Creating Machine('brill')...done.
+Creating Machine('char')...done.
+Creating Machine('cod')...done.
+Creating Machine('dorado')...done.
+Creating Machine('eel')...done.
+Creating Machine('flounder')...done.
+Creating Machine('grouper')...done.
+Creating Machine('halibut')...done.
+Creating Machine('herring')...done.
+Creating Machine('mackerel')...done.
+Creating Machine('marlin')...done.
+Creating Machine('perch')...done.
+Creating Machine('pollock')...done.
+Creating Machine('sardine')...done.
+Creating Machine('shark')...done.
+Creating Machine('sole')...done.
+Creating Machine('swordfish')...done.
+Creating Machine('tarpon')...done.
+Creating Machine('turbot')...done.
+Creating Machine('wahoo')...done.
+
+Creating tasks for parent (2500, 2500, 2500) ...
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 3125) : 3.710625 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 625) : 4.294574 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 625) : 4.397856 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 1875) : 3.838223 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 3125) : 3.889282 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 4375) : 3.89124 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 625) : 4.283442 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 3125) : 3.708128 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 1875) : 3.834247 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 625) : 4.420664 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 625) : 4.39062 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 1875) : 4.138 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 1875) : 4.158499 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 1875) : 3.792151 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 1875) : 3.853875 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 3125) : 3.761442 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 4375) : 4.29519 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 625) : 4.379211 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 1875) : 4.109232 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 1875) : 4.326434 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 3125) : 4.423898 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 1875) : 3.803906 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 4375) : 4.056973 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 625) : 4.302141 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 625) : 4.416395 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 1875) : 4.112351 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 3125) : 4.532593 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 3125) : 4.814011 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 3125) : 4.558592 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 3125) : 4.527983 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 3125) : 4.121241 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 4375) : 4.669492 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 4375) : 4.644398 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 4375) : 4.732175 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 625) : 4.632749 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 625) : 4.570968 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 625) : 4.583254 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 4375) : 5.787906 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 4375) : 3.838831 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 625) : 4.750462 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (625, 625, 625) : 4.263677 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 625) : 4.392737 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 625) : 4.602541 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 4375) : 4.644654 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 1875) : 4.75942 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 1875) : 4.765401 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 1875) : 4.713596 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 1875) : 4.815275 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 1875) : 5.832807 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 3125) : 5.048782 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 3125) : 5.104958 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (625, 1875, 4375) : 4.698696 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 3125) : 4.974922 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 3125) : 4.918813 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 4375) : 5.114436 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 4375) : 5.209979 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 3125) : 5.690528 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 4375) : 5.174039 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 625) : 4.981161 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 4375) : 5.250589 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (625, 3125, 4375) : 5.326543 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 625) : 5.054585 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 625) : 5.005346 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 625) : 5.190905 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 1875) : 5.60465 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 1875) : 5.632111 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 1875) : 5.612299 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 1875) : 5.63952 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 1875) : 5.645899 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 3125) : 5.887925 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 3125) : 5.834338 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 3125) : 5.975766 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 625) : 4.364144 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 3125) : 5.859661 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 625) : 9.110578 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 4375) : 5.842534 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 4375) : 5.886027 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 4375) : 5.910465 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 625) : 4.293523 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 1875) : 3.791773 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 625) : 4.279034 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 1875) : 3.845577 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 1875) : 3.911537 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 625) : 4.369147 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 625) : 4.310929 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 4375) : 5.802452 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 4375) : 5.781715 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 1875) : 3.808935 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 1875) : 3.841432 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (625, 4375, 3125) : 6.202746 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 3125) : 3.721264 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 3125) : 3.864011 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 3125) : 3.694681 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 3125) : 3.707615 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 3125) : 3.693069 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 4375) : 3.873732 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 4375) : 3.863359 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 4375) : 3.875816 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 4375) : 3.841439 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 625) : 4.396369 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 625) : 4.43895 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 625) : 4.414212 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 625) : 4.421599 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 625) : 4.395128 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 1875) : 4.147579 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 1875) : 4.216733 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 1875) : 4.304359 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 1875) : 4.142816 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (1875, 625, 4375) : 5.780457 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 3125) : 4.532663 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 3125) : 4.484811 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 3125) : 4.421408 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 3125) : 4.507557 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 1875) : 4.099743 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 4375) : 4.662055 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 3125) : 5.110452 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 4375) : 4.577764 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 4375) : 4.583778 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 4375) : 4.63845 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (1875, 1875, 4375) : 4.749432 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 625) : 4.616889 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 625) : 4.755435 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 625) : 5.159468 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 625) : 4.630655 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 625) : 4.581085 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 1875) : 4.76344 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 1875) : 4.777199 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 3125) : 4.954945 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 3125) : 4.960184 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 3125) : 4.90662 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 4375) : 5.162779 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 1875) : 4.726656 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 1875) : 4.732855 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 4375) : 5.095509 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 4375) : 5.168714 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 4375) : 5.276807 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 3125) : 5.142618 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 625) : 5.017106 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 625) : 4.941091 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 625) : 5.105011 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 625) : 5.158132 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 625) : 5.035103 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 3125) : 8.490825 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 4375) : 5.499865 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 1875) : 5.661534 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 1875) : 5.696976 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 1875) : 5.582436 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 1875) : 5.599575 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (1875, 3125, 1875) : 4.952876 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 3125) : 5.774361 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 3125) : 5.839603 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 1875) : 7.40745 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 625) : 4.286527 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 3125) : 5.880967 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 3125) : 5.903846 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 625) : 4.331346 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 625) : 4.767882 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 3125) : 5.873788 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 625) : 4.328215 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 4375) : 5.845694 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 4375) : 5.81161 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 1875) : 3.871006 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 4375) : 5.893888 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 4375) : 6.034824 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 625) : 4.330451 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 1875) : 3.826929 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 1875) : 4.157173 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 3125) : 3.73229 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 1875) : 3.859185 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 3125) : 3.696805 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 1875) : 5.460627 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (1875, 4375, 4375) : 5.754628 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 3125) : 3.911659 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 3125) : 3.86644 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 3125) : 3.685201 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 4375) : 3.870586 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 4375) : 3.81721 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 4375) : 4.302085 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 4375) : 3.822001 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (3125, 625, 4375) : 3.85542 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 625) : 4.650253 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 625) : 4.39401 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 625) : 4.474391 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 625) : 4.382032 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 625) : 4.420899 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 1875) : 4.106117 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 1875) : 4.218727 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 1875) : 4.07656 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 1875) : 4.193761 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 1875) : 4.159823 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 3125) : 4.444336 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 3125) : 5.010875 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 4375) : 4.693483 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 4375) : 4.641713 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 4375) : 4.918603 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 4375) : 4.715156 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 625) : 4.555371 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 4375) : 4.653009 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 625) : 4.612201 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 3125) : 4.483999 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 625) : 4.828283 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 625) : 4.695966 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 625) : 4.813558 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 3125) : 7.624713 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 1875) : 4.77343 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 1875) : 4.953969 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 1875) : 4.779383 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 1875) : 4.791881 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 3125) : 4.94807 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 1875, 3125) : 4.489004 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 3125) : 5.072089 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 3125) : 5.030172 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 3125) : 5.013907 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 1875) : 4.828116 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 3125) : 4.97212 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 4375) : 5.214743 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 4375) : 5.605392 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 4375) : 5.294402 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 4375) : 5.245285 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (3125, 3125, 4375) : 5.24283 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 625) : 5.032826 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 625) : 5.20819 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 625) : 5.044549 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 625) : 5.729921 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 1875) : 5.70163 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 625) : 5.007341 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 1875) : 5.663743 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 1875) : 5.83254 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 1875) : 5.636599 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 3125) : 5.869921 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 3125) : 5.902459 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 3125) : 5.867071 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 3125) : 5.957093 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 4375) : 5.862012 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 4375) : 5.966497 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 625) : 4.58238 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 625) : 4.346322 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 4375) : 5.852064 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 625) : 4.307822 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 4375) : 5.819139 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 1875) : 3.823505 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 1875) : 3.810772 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 3125) : 5.824378 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 625) : 4.784143 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 625) : 4.316682 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 4375) : 5.716346 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 1875) : 3.814088 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (3125, 4375, 1875) : 9.10212 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 1875) : 3.979105 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 1875) : 3.828959 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 3125) : 3.897378 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 3125) : 3.734559 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 3125) : 3.701657 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 3125) : 3.74392 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 4375) : 3.988487 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 4375) : 3.814293 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 4375) : 3.85805 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 4375) : 3.834111 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 4375) : 4.048825 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 625) : 4.451613 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 625) : 4.442037 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 625) : 4.44985 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 1875) : 4.199074 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 1875) : 4.253859 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 625) : 4.415506 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 625) : 4.464758 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 1875) : 4.126622 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (4375, 625, 3125) : 3.694261 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 3125) : 4.411581 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 3125) : 4.961181 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 3125) : 4.500448 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 1875) : 4.081821 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 3125) : 4.651087 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 4375) : 4.629183 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 4375) : 4.800552 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 4375) : 4.657735 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 4375) : 4.635171 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 4375) : 4.611421 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 625) : 4.622097 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 1875) : 4.154726 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 625) : 4.625322 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (4375, 1875, 3125) : 7.607887 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 625) : 4.561323 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 625) : 5.294793 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 625) : 4.738107 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 1875) : 4.709369 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 1875) : 4.774694 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 1875) : 4.776258 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 1875) : 4.724665 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 3125) : 4.900222 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 3125) : 4.992245 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 3125) : 4.936086 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 3125) : 4.993336 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 1875) : 4.845081 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 3125) : 4.960727 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 4375) : 5.135424 seconds
+Result [sardine-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 4375) : 5.107684 seconds
+Result [grouper-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 4375) : 5.27961 seconds
+Result [blowfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 4375) : 5.10304 seconds
+Result [char-0] : level-0 : parent(2500, 2500, 2500) : (4375, 3125, 4375) : 5.114011 seconds
+Result [eel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 625) : 4.996619 seconds
+Result [dorado-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 625) : 4.995802 seconds
+Result [marlin-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 625) : 5.05606 seconds
+Result [mackerel-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 625) : 5.047597 seconds
+Result [turbot-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 1875) : 5.536729 seconds
+Result [bonito-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 1875) : 5.575 seconds
+Result [anchovy-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 625) : 5.135543 seconds
+Result [cod-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 3125) : 5.794987 seconds
+Result [sole-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 1875) : 6.059103 seconds
+Result [halibut-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 3125) : 5.814463 seconds
+Result [barracuda-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 3125) : 6.016603 seconds
+Result [flounder-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 3125) : 5.781405 seconds
+Result [pollock-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 3125) : 5.856073 seconds
+Result [wahoo-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 4375) : 5.798266 seconds
+Result [brill-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 1875) : 5.623945 seconds
+Result [tarpon-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 4375) : 5.91652 seconds
+Result [shark-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 4375) : 5.987031 seconds
+Result [perch-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 1875) : 9.36817 seconds
+Result [herring-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 4375) : 6.536649 seconds
+Result [swordfish-0] : level-0 : parent(2500, 2500, 2500) : (4375, 4375, 4375) : 5.790292 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (1875, 625, 3125) 3.736128 seconds
+Selected : (4375, 625, 3125) 3.754355 seconds
+Selected : (3125, 625, 3125) 3.778479 seconds
+...done.
+
+Creating tasks for parent (1875, 625, 3125) ...
+Result [bonito-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 2812) : 3.719479 seconds
+Result [char-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 3437) : 3.885727 seconds
+Result [barracuda-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 2812) : 3.834224 seconds
+Result [sole-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 3437) : 4.060499 seconds
+Result [blowfish-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 2812) : 3.700232 seconds
+Result [flounder-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 3437) : 3.716882 seconds
+Result [eel-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 3437) : 3.7847 seconds
+Result [marlin-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 2812) : 3.910107 seconds
+Result [anchovy-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 2812) : 3.672895 seconds
+Result [dorado-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 3437) : 3.71657 seconds
+Result [pollock-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 3437) : 3.794237 seconds
+Result [grouper-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 2812) : 3.898532 seconds
+Result [bonito-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 2812) : 3.695308 seconds
+Result [char-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 3437) : 3.893211 seconds
+Result [sole-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 3437) : 3.968098 seconds
+Result [perch-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 3437) : 5.824472 seconds
+Result [halibut-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 2812) : 3.805484 seconds
+Result [mackerel-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 2812) : 3.787254 seconds
+Result [blowfish-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 3437) : 3.775535 seconds
+Result [eel-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 2812) : 3.753766 seconds
+Result [flounder-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 3437) : 3.879149 seconds
+Result [barracuda-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 3437) : 3.890417 seconds
+Result [marlin-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 2812) : 3.769616 seconds
+Result [cod-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 3437) : 3.738343 seconds
+Result [anchovy-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 2812) : 3.766692 seconds
+Result [dorado-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 2812) : 3.753154 seconds
+Result [pollock-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 2812) : 3.706476 seconds
+Result [shark-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 3437) : 4.206988 seconds
+Result [bonito-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 3437) : 3.752042 seconds
+Result [char-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 3437) : 3.791148 seconds
+Result [sole-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 3437) : 4.049396 seconds
+Result [grouper-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 3437) : 3.918922 seconds
+Result [herring-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 2812) : 4.755354 seconds
+Result [turbot-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 2812) : 3.673342 seconds
+Result [perch-0] : level-1 : parent(1875, 625, 3125) : (2187, 937, 3437) : 5.861372 seconds
+Result [tarpon-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 2812) : 3.685401 seconds
+Result [wahoo-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 2812) : 3.731252 seconds
+Result [swordfish-0] : level-1 : parent(1875, 625, 3125) : (2187, 312, 2812) : 3.685087 seconds
+Result [sardine-0] : level-1 : parent(1875, 625, 3125) : (1562, 937, 3437) : 3.940085 seconds
+Result [brill-0] : level-1 : parent(1875, 625, 3125) : (1562, 312, 2812) : 3.707675 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (2187, 312, 2812) 3.6940779999999998 seconds
+Selected : (1562, 312, 2812) 3.7269010000000002 seconds
+Selected : (2187, 937, 2812) 3.7499408 seconds
+...done.
+
+Creating tasks for parent (2187, 312, 2812) ...
+Result [brill-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2656) : 3.674696 seconds
+Result [halibut-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2656) : 3.665465 seconds
+Result [dorado-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2968) : 3.698374 seconds
+Result [anchovy-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2656) : 3.66238 seconds
+Result [barracuda-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2656) : 3.830395 seconds
+Result [blowfish-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2656) : 3.675451 seconds
+Result [mackerel-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2656) : 3.686558 seconds
+Result [marlin-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2656) : 3.701107 seconds
+Result [shark-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2968) : 3.752189 seconds
+Result [char-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2968) : 3.792843 seconds
+Result [brill-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2656) : 3.6702 seconds
+Result [dorado-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2968) : 3.695346 seconds
+Result [anchovy-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2968) : 3.674056 seconds
+Result [halibut-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2968) : 3.761892 seconds
+Result [barracuda-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2968) : 3.686293 seconds
+Result [grouper-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2656) : 4.068733 seconds
+Result [perch-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2968) : 5.48008 seconds
+Result [flounder-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2968) : 3.696399 seconds
+Result [pollock-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2968) : 3.685084 seconds
+Result [mackerel-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2656) : 3.731798 seconds
+Result [blowfish-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2968) : 3.842972 seconds
+Result [shark-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2656) : 4.157738 seconds
+Result [eel-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2968) : 3.701558 seconds
+Result [sole-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2968) : 4.029949 seconds
+Result [char-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2656) : 3.734274 seconds
+Result [dorado-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2968) : 3.722821 seconds
+Result [halibut-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2968) : 3.705031 seconds
+Result [wahoo-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2656) : 3.707728 seconds
+Result [brill-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2656) : 3.702221 seconds
+Result [anchovy-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2968) : 3.856769 seconds
+Result [grouper-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2968) : 3.884692 seconds
+Result [herring-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2656) : 3.874031 seconds
+Result [marlin-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2656) : 3.728784 seconds
+Result [barracuda-0] : level-2 : parent(2187, 312, 2812) : (2343, 468, 2968) : 3.726461 seconds
+Result [sardine-0] : level-2 : parent(2187, 312, 2812) : (2031, 468, 2968) : 3.689346 seconds
+Result [turbot-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2656) : 3.827941 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [swordfish-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2656) : 3.673011 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [cod-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2968) : 3.706007 seconds
+Result [tarpon-0] : level-2 : parent(2187, 312, 2812) : (2343, 156, 2656) : 3.709474 seconds
+Result [bonito-0] : level-2 : parent(2187, 312, 2812) : (2031, 156, 2656) : 3.70603 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (2031, 156, 2656) 3.7097904 seconds
+Selected : (2343, 156, 2656) 3.7176708 seconds
+Selected : (2031, 156, 2968) 3.7190362 seconds
+...done.
+
+Creating tasks for parent (2031, 156, 2656) ...
+Result [brill-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2578) : 3.671213 seconds
+Result [barracuda-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2578) : 3.675728 seconds
+Result [blowfish-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2578) : 3.681179 seconds
+Result [wahoo-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2578) : 3.667019 seconds
+Result [halibut-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2578) : 3.664941 seconds
+Result [bonito-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2578) : 3.657278 seconds
+Result [flounder-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2734) : 3.711596 seconds
+Result [herring-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2578) : 3.846617 seconds
+Result [cod-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2734) : 3.669575 seconds
+Result [sardine-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2734) : 3.692276 seconds
+Result [dorado-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2734) : 3.70383 seconds
+Result [swordfish-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2578) : 3.714331 seconds
+Result [brill-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2578) : 3.675685 seconds
+Result [barracuda-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2734) : 3.699262 seconds
+Result [wahoo-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2734) : 3.670363 seconds
+Result [anchovy-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2578) : 3.734608 seconds
+Result [grouper-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2578) : 3.838073 seconds
+Result [mackerel-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2578) : 3.818708 seconds
+Result [marlin-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2578) : 3.83252 seconds
+Result [sole-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2734) : 3.999077 seconds
+Result [herring-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2578) : 3.712947 seconds
+Result [bonito-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2734) : 3.827912 seconds
+Result [eel-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2734) : 3.679078 seconds
+Result [sardine-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2578) : 3.684056 seconds
+Result [cod-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2578) : 3.692615 seconds
+Result [dorado-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2578) : 3.65241 seconds
+Result [halibut-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2734) : 3.70747 seconds
+Result [brill-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2734) : 3.668087 seconds
+Result [swordfish-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2734) : 3.713964 seconds
+Result [barracuda-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2734) : 3.8414 seconds
+Result [perch-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2734) : 5.353167 seconds
+Result [turbot-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2578) : 3.701868 seconds
+Result [flounder-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2578) : 3.692261 seconds
+Result [anchovy-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2734) : 3.836189 seconds
+Result [wahoo-0] : level-3 : parent(2031, 156, 2656) : (2109, 234, 2734) : 3.675438 seconds
+Result [tarpon-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2578) : 3.670677 seconds
+Result [blowfish-0] : level-3 : parent(2031, 156, 2656) : (2109, 78, 2734) : 3.699984 seconds
+Result [shark-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2734) : 4.120998 seconds
+Result [char-0] : level-3 : parent(2031, 156, 2656) : (1953, 78, 2734) : 3.676503 seconds
+Result [pollock-0] : level-3 : parent(2031, 156, 2656) : (1953, 234, 2734) : 3.694955 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1953, 78, 2578) 3.6840012 seconds
+...done.
+
+OPTIMAL : (1953, 78, 2578) 3.6840012 seconds : 11.310166420865082 GFlops/sec
+
+Creating tasks for parent (2343, 156, 2656) ...
+Result [brill-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2578) : 3.67798 seconds
+Result [grouper-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2578) : 3.776205 seconds
+Result [marlin-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2578) : 3.712731 seconds
+Result [shark-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2734) : 3.78069 seconds
+Result [anchovy-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2578) : 3.669569 seconds
+Result [pollock-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2734) : 3.657856 seconds
+Result [turbot-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2578) : 3.699737 seconds
+Result [barracuda-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2578) : 3.835791 seconds
+Result [eel-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2734) : 3.680548 seconds
+Result [dorado-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2734) : 3.728456 seconds
+Result [brill-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2578) : 3.71885 seconds
+Result [marlin-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2734) : 3.712837 seconds
+Result [grouper-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2734) : 4.09441 seconds
+Result [shark-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2734) : 4.123404 seconds
+Result [char-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2734) : 3.758694 seconds
+Result [flounder-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2734) : 3.836942 seconds
+Result [pollock-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2734) : 3.666723 seconds
+Result [anchovy-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2734) : 3.716229 seconds
+Result [turbot-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2578) : 3.72409 seconds
+Result [barracuda-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2578) : 3.674279 seconds
+Result [blowfish-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2578) : 3.677361 seconds
+Result [wahoo-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2578) : 3.702336 seconds
+Result [eel-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2578) : 3.741198 seconds
+Result [brill-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2578) : 3.671075 seconds
+Result [marlin-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2734) : 3.678094 seconds
+Result [shark-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2734) : 3.87378 seconds
+Result [grouper-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2734) : 3.995598 seconds
+Result [mackerel-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2578) : 3.657234 seconds
+Result [bonito-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2578) : 3.673634 seconds
+Result [dorado-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2578) : 3.700731 seconds
+Result [char-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2734) : 3.674474 seconds
+Result [flounder-0] : level-3 : parent(2343, 156, 2656) : (2421, 234, 2734) : 3.703212 seconds
+Result [swordfish-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2578) : 3.676565 seconds
+Result [sole-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2734) : 3.961275 seconds
+Result [cod-0] : level-3 : parent(2343, 156, 2656) : (2265, 78, 2734) : 3.698658 seconds
+Result [perch-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2734) : 5.495659 seconds
+Result [halibut-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2578) : 3.678043 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [herring-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2578) : 3.907565 seconds
+Result [tarpon-0] : level-3 : parent(2343, 156, 2656) : (2421, 78, 2578) : 3.680263 seconds
+Result [sardine-0] : level-3 : parent(2343, 156, 2656) : (2265, 234, 2734) : 3.704097 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (2421, 78, 2578) 3.6955502 seconds
+...done.
+
+OPTIMAL : (2421, 78, 2578) 3.6955502 seconds : 11.274820909391696 GFlops/sec
+
+Creating tasks for parent (2031, 156, 2968) ...
+Result [dorado-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 3046) : 3.693905 seconds
+Result [bonito-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 2890) : 3.684486 seconds
+Result [tarpon-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 2890) : 3.691489 seconds
+Result [grouper-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 2890) : 3.845846 seconds
+Result [cod-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 3046) : 3.687027 seconds
+Result [perch-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 3046) : 5.253304 seconds
+Result [barracuda-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 2890) : 3.674441 seconds
+Result [char-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 3046) : 3.733284 seconds
+Result [wahoo-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 2890) : 3.731793 seconds
+Result [blowfish-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 2890) : 3.727641 seconds
+Result [brill-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 2890) : 3.729265 seconds
+Result [marlin-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 2890) : 3.681362 seconds
+Result [pollock-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 3046) : 3.683476 seconds
+Result [anchovy-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 2890) : 3.681123 seconds
+Result [dorado-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 2890) : 3.724237 seconds
+Result [tarpon-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 3046) : 3.707733 seconds
+Result [grouper-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 3046) : 3.853914 seconds
+Result [mackerel-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 2890) : 3.6809 seconds
+Result [swordfish-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 2890) : 3.68094 seconds
+Result [sardine-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 3046) : 3.751097 seconds
+Result [barracuda-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 2890) : 3.687931 seconds
+Result [bonito-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 3046) : 3.676818 seconds
+Result [wahoo-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 2890) : 3.715771 seconds
+Result [perch-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 3046) : 5.344956 seconds
+Result [flounder-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 3046) : 3.683145 seconds
+Result [halibut-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 2890) : 3.702212 seconds
+Result [shark-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 3046) : 3.910179 seconds
+Result [cod-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 3046) : 3.676628 seconds
+Result [char-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 2890) : 3.714239 seconds
+Result [brill-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 2890) : 3.846948 seconds
+Result [marlin-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 3046) : 3.85032 seconds
+Result [sole-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 3046) : 4.03138 seconds
+Result [blowfish-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 2890) : 3.84844 seconds
+Result [dorado-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 3046) : 3.710996 seconds
+Result [tarpon-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 3046) : 3.705773 seconds
+Result [eel-0] : level-3 : parent(2031, 156, 2968) : (1953, 78, 3046) : 3.691949 seconds
+Result [pollock-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 3046) : 3.721809 seconds
+Result [turbot-0] : level-3 : parent(2031, 156, 2968) : (2109, 78, 2890) : 3.724225 seconds
+Result [anchovy-0] : level-3 : parent(2031, 156, 2968) : (2109, 234, 3046) : 3.732195 seconds
+Result [herring-0] : level-3 : parent(2031, 156, 2968) : (1953, 234, 2890) : 3.831223 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1953, 78, 3046) 3.697862 seconds
+...done.
+
+OPTIMAL : (1953, 78, 3046) 3.697862 seconds : 11.26777220639025 GFlops/sec
+
+Creating tasks for parent (1562, 312, 2812) ...
+Result [bonito-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2656) : 3.657395 seconds
+Result [wahoo-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2656) : 3.662874 seconds
+Result [mackerel-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2656) : 3.720421 seconds
+Result [brill-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2656) : 3.815351 seconds
+Result [blowfish-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2656) : 3.688255 seconds
+Result [turbot-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2656) : 3.713323 seconds
+Result [grouper-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2656) : 4.115924 seconds
+Result [perch-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2968) : 5.372789 seconds
+Result [flounder-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2968) : 3.700434 seconds
+Result [bonito-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2656) : 3.686747 seconds
+Result [sole-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2968) : 3.846584 seconds
+Result [mackerel-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2968) : 3.698392 seconds
+Result [brill-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2968) : 3.688038 seconds
+Result [dorado-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2968) : 3.829093 seconds
+Result [sardine-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2968) : 3.807215 seconds
+Result [blowfish-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2968) : 3.684501 seconds
+Result [wahoo-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2968) : 3.708827 seconds
+Result [shark-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2968) : 4.135032 seconds
+Result [grouper-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2656) : 4.088037 seconds
+Result [char-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2968) : 3.721748 seconds
+Result [halibut-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2656) : 3.704188 seconds
+Result [swordfish-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2656) : 3.660406 seconds
+Result [anchovy-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2656) : 3.81608 seconds
+Result [flounder-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2656) : 3.650995 seconds
+Result [turbot-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2968) : 3.671915 seconds
+Result [bonito-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2656) : 3.676477 seconds
+Result [sole-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2656) : 3.887882 seconds
+Result [brill-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2968) : 3.675813 seconds
+Result [mackerel-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2968) : 3.858824 seconds
+Result [perch-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2656) : 5.52367 seconds
+Result [barracuda-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2656) : 3.702966 seconds
+Result [dorado-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2968) : 3.72089 seconds
+Result [blowfish-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2968) : 3.724892 seconds
+Result [pollock-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2968) : 3.693004 seconds
+Result [eel-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2968) : 3.705831 seconds
+Result [sardine-0] : level-2 : parent(1562, 312, 2812) : (1718, 468, 2968) : 3.693024 seconds
+Result [marlin-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2656) : 3.669503 seconds
+Result [herring-0] : level-2 : parent(1562, 312, 2812) : (1406, 468, 2656) : 3.968296 seconds
+Result [cod-0] : level-2 : parent(1562, 312, 2812) : (1406, 156, 2968) : 3.714413 seconds
+Result [tarpon-0] : level-2 : parent(1562, 312, 2812) : (1718, 156, 2656) : 3.673276 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (1718, 156, 2656) 3.6793252 seconds
+Selected : (1718, 156, 2968) 3.6903346 seconds
+Selected : (1406, 156, 2968) 3.7343037999999997 seconds
+...done.
+
+Creating tasks for parent (1718, 156, 2656) ...
+Result [dorado-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2734) : 3.671425 seconds
+Result [marlin-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2578) : 3.702397 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2578) : 3.66552 seconds
+Result [halibut-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2578) : 3.697894 seconds
+Result [turbot-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2578) : 3.667083 seconds
+Result [barracuda-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2578) : 3.692743 seconds
+Result [grouper-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2578) : 3.764016 seconds
+Result [pollock-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2734) : 3.666797 seconds
+Result [perch-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2734) : 5.378248 seconds
+Result [brill-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2578) : 3.71923 seconds
+Result [bonito-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2578) : 3.698693 seconds
+Result [anchovy-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2578) : 3.666584 seconds
+Result [cod-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2734) : 3.827038 seconds
+Result [marlin-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2734) : 3.693982 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2734) : 3.656351 seconds
+Result [char-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2734) : 3.703901 seconds
+Result [swordfish-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2578) : 3.668466 seconds
+Result [pollock-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2578) : 3.70585 seconds
+Result [barracuda-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2734) : 3.756527 seconds
+Result [grouper-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2578) : 3.809946 seconds
+Result [wahoo-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2578) : 3.700334 seconds
+Result [dorado-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2578) : 3.67268 seconds
+Result [brill-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2578) : 3.668411 seconds
+Result [turbot-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2734) : 3.658271 seconds
+Result [cod-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2734) : 3.708491 seconds
+Result [marlin-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2734) : 3.681425 seconds
+Result [perch-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2578) : 5.27472 seconds
+Result [eel-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2734) : 3.666946 seconds
+Result [char-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2734) : 3.664347 seconds
+Result [halibut-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2734) : 3.664611 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2734) : 3.680267 seconds
+Result [flounder-0] : level-3 : parent(1718, 156, 2656) : (1640, 78, 2734) : 3.819757 seconds
+Result [anchovy-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2734) : 3.656547 seconds
+Result [shark-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2734) : 4.145963 seconds
+Result [tarpon-0] : level-3 : parent(1718, 156, 2656) : (1796, 78, 2578) : 3.661134 seconds
+Result [bonito-0] : level-3 : parent(1718, 156, 2656) : (1796, 234, 2578) : 3.822466 seconds
+Result [sole-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2734) : 4.051966 seconds
+Result [herring-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2578) : 3.700233 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [mackerel-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2578) : 3.668384 seconds
+Result [sardine-0] : level-3 : parent(1718, 156, 2656) : (1640, 234, 2734) : 3.693374 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1796, 78, 2578) 3.6739394 seconds
+...done.
+
+OPTIMAL : (1796, 78, 2578) 3.6739394 seconds : 11.341141518737805 GFlops/sec
+
+Creating tasks for parent (1718, 156, 2968) ...
+Result [barracuda-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 2890) : 3.67708 seconds
+Result [bonito-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 2890) : 3.759044 seconds
+Result [sardine-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 3046) : 3.677012 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 2890) : 3.703931 seconds
+Result [anchovy-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 2890) : 3.704014 seconds
+Result [flounder-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 3046) : 3.681751 seconds
+Result [dorado-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 3046) : 3.845035 seconds
+Result [herring-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 2890) : 3.995201 seconds
+Result [brill-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 2890) : 3.68821 seconds
+Result [halibut-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 2890) : 3.670615 seconds
+Result [wahoo-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 2890) : 3.709985 seconds
+Result [sardine-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 3046) : 3.669923 seconds
+Result [bonito-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 3046) : 3.718488 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 3046) : 3.745646 seconds
+Result [pollock-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 3046) : 3.700729 seconds
+Result [marlin-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 2890) : 3.835981 seconds
+Result [flounder-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 3046) : 3.678837 seconds
+Result [barracuda-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 2890) : 3.731181 seconds
+Result [dorado-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 2890) : 3.696429 seconds
+Result [herring-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 2890) : 3.873661 seconds
+Result [eel-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 3046) : 3.723576 seconds
+Result [swordfish-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 2890) : 3.711146 seconds
+Result [tarpon-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 2890) : 3.702099 seconds
+Result [brill-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 2890) : 3.683543 seconds
+Result [anchovy-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 3046) : 3.704486 seconds
+Result [wahoo-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 2890) : 3.709652 seconds
+Result [bonito-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 3046) : 3.672616 seconds
+Result [sardine-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 3046) : 3.787437 seconds
+Result [blowfish-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 3046) : 3.67257 seconds
+Result [char-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 3046) : 3.687172 seconds
+Result [halibut-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 2890) : 3.660122 seconds
+Result [pollock-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 3046) : 3.713732 seconds
+Result [marlin-0] : level-3 : parent(1718, 156, 2968) : (1796, 234, 3046) : 3.705129 seconds
+Result [perch-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 3046) : 5.445289 seconds
+Result [turbot-0] : level-3 : parent(1718, 156, 2968) : (1796, 78, 2890) : 3.734165 seconds
+Result [cod-0] : level-3 : parent(1718, 156, 2968) : (1640, 78, 3046) : 3.715927 seconds
+Result [mackerel-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 2890) : 3.718488 seconds
+Result [shark-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 3046) : 3.849148 seconds
+Result [sole-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 3046) : 3.981759 seconds
+Result [grouper-0] : level-3 : parent(1718, 156, 2968) : (1640, 234, 2890) : 4.075155 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1796, 78, 3046) 3.7034759999999998 seconds
+...done.
+
+OPTIMAL : (1796, 78, 3046) 3.7034759999999998 seconds : 11.250691692525256 GFlops/sec
+
+Creating tasks for parent (1406, 156, 2968) ...
+Result [char-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 3046) : 3.675621 seconds
+Result [barracuda-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 2890) : 3.666994 seconds
+Result [sardine-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 3046) : 3.69626 seconds
+Result [turbot-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 2890) : 3.72218 seconds
+Result [grouper-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 2890) : 3.861896 seconds
+Result [herring-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 2890) : 3.76639 seconds
+Result [flounder-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 3046) : 3.670269 seconds
+Result [eel-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 3046) : 3.757885 seconds
+Result [perch-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 3046) : 5.482714 seconds
+Result [brill-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 2890) : 3.682179 seconds
+Result [char-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 2890) : 3.655704 seconds
+Result [shark-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 3046) : 3.771802 seconds
+Result [pollock-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 3046) : 3.735236 seconds
+Result [barracuda-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 3046) : 3.690816 seconds
+Result [sardine-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 3046) : 3.675775 seconds
+Result [grouper-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 3046) : 3.834698 seconds
+Result [blowfish-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 2890) : 3.705232 seconds
+Result [marlin-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 2890) : 3.710881 seconds
+Result [flounder-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 2890) : 3.660701 seconds
+Result [sole-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 3046) : 3.923678 seconds
+Result [eel-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 2890) : 3.707388 seconds
+Result [herring-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 3046) : 3.78835 seconds
+Result [turbot-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 3046) : 3.697847 seconds
+Result [anchovy-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 2890) : 3.665365 seconds
+Result [halibut-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 2890) : 3.668039 seconds
+Result [mackerel-0] : level-3 : parent(1406, 156, 2968) : (1328, 234, 2890) : 3.699719 seconds
+Result [cod-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 3046) : 3.691918 seconds
+Result [brill-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 2890) : 3.681736 seconds
+Result [pollock-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 3046) : 3.694612 seconds
+Result [char-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 2890) : 3.681273 seconds
+Result [barracuda-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 3046) : 3.723409 seconds
+Result [sardine-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 3046) : 3.675222 seconds
+Result [grouper-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 3046) : 3.837354 seconds
+Result [perch-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 2890) : 5.36352 seconds
+Result [bonito-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 2890) : 3.699978 seconds
+Result [tarpon-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 2890) : 3.698934 seconds
+Result [shark-0] : level-3 : parent(1406, 156, 2968) : (1484, 234, 3046) : 3.790828 seconds
+Result [swordfish-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 2890) : 3.668969 seconds
+Result [wahoo-0] : level-3 : parent(1406, 156, 2968) : (1484, 78, 2890) : 3.726441 seconds
+Result [dorado-0] : level-3 : parent(1406, 156, 2968) : (1328, 78, 3046) : 3.700868 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1328, 78, 2890) 3.6839496 seconds
+...done.
+
+OPTIMAL : (1328, 78, 2890) 3.6839496 seconds : 11.310324839044124 GFlops/sec
+
+Creating tasks for parent (2187, 937, 2812) ...
+Result [bonito-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2656) : 3.686298 seconds
+Result [barracuda-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2656) : 3.705941 seconds
+Result [halibut-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2656) : 3.857136 seconds
+Result [flounder-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2968) : 3.867868 seconds
+Result [anchovy-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2656) : 3.693047 seconds
+Result [cod-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2968) : 3.75473 seconds
+Result [tarpon-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2656) : 3.753034 seconds
+Result [blowfish-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2656) : 3.852451 seconds
+Result [barracuda-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2968) : 3.731839 seconds
+Result [sole-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2968) : 4.182134 seconds
+Result [perch-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2968) : 6.338417 seconds
+Result [halibut-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2968) : 3.87062 seconds
+Result [char-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2968) : 3.717275 seconds
+Result [bonito-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2656) : 3.696545 seconds
+Result [marlin-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2656) : 3.895296 seconds
+Result [anchovy-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2968) : 3.736789 seconds
+Result [cod-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2968) : 3.69075 seconds
+Result [flounder-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2968) : 3.745928 seconds
+Result [swordfish-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2656) : 3.692031 seconds
+Result [dorado-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2968) : 3.857902 seconds
+Result [blowfish-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2656) : 3.940091 seconds
+Result [barracuda-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2656) : 3.800881 seconds
+Result [halibut-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2968) : 3.814609 seconds
+Result [herring-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2656) : 4.953713 seconds
+Result [sole-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2656) : 4.195198 seconds
+Result [char-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2968) : 3.806185 seconds
+Result [shark-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2968) : 4.159456 seconds
+Result [tarpon-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2656) : 3.92405 seconds
+Result [marlin-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2968) : 3.809333 seconds
+Result [bonito-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2968) : 3.8409 seconds
+Result [turbot-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2656) : 3.738166 seconds
+Result [eel-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2968) : 3.753744 seconds
+Result [anchovy-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2968) : 4.100401 seconds
+Result [perch-0] : level-2 : parent(2187, 937, 2812) : (2343, 1093, 2656) : 6.452548 seconds
+Result [mackerel-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2656) : 3.851034 seconds
+Result [brill-0] : level-2 : parent(2187, 937, 2812) : (2031, 781, 2656) : 3.709224 seconds
+Result [pollock-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2968) : 3.769131 seconds
+Result [grouper-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2656) : 4.129682 seconds
+Result [wahoo-0] : level-2 : parent(2187, 937, 2812) : (2343, 781, 2656) : 3.769732 seconds
+Result [sardine-0] : level-2 : parent(2187, 937, 2812) : (2031, 1093, 2968) : 3.867384 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (2031, 781, 2656) 3.7293922 seconds
+Selected : (2343, 781, 2656) 3.7299016 seconds
+Selected : (2343, 781, 2968) 3.7551852 seconds
+...done.
+
+Creating tasks for parent (2031, 781, 2656) ...
+Result [barracuda-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2578) : 3.717353 seconds
+Result [brill-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2578) : 3.716778 seconds
+Result [bonito-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2578) : 3.672802 seconds
+Result [eel-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2734) : 3.738737 seconds
+Result [grouper-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2578) : 3.919971 seconds
+Result [sole-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2734) : 3.970969 seconds
+Result [dorado-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2734) : 3.68776 seconds
+Result [blowfish-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2578) : 3.696662 seconds
+Result [flounder-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2734) : 3.704956 seconds
+Result [wahoo-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2578) : 3.674421 seconds
+Result [perch-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2734) : 5.884853 seconds
+Result [turbot-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2578) : 3.840257 seconds
+Result [barracuda-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2578) : 3.697245 seconds
+Result [eel-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2734) : 3.766284 seconds
+Result [brill-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2734) : 3.738123 seconds
+Result [grouper-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2734) : 3.771161 seconds
+Result [sole-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2734) : 3.939368 seconds
+Result [char-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2734) : 3.709314 seconds
+Result [tarpon-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2578) : 3.687717 seconds
+Result [mackerel-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2578) : 3.731958 seconds
+Result [dorado-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2578) : 3.677048 seconds
+Result [bonito-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2734) : 3.69446 seconds
+Result [pollock-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2734) : 3.727493 seconds
+Result [halibut-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2578) : 3.762317 seconds
+Result [flounder-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2578) : 3.716814 seconds
+Result [wahoo-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2578) : 3.714138 seconds
+Result [blowfish-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2578) : 3.795001 seconds
+Result [barracuda-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2734) : 3.75219 seconds
+Result [brill-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2734) : 3.870453 seconds
+Result [grouper-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2734) : 3.883199 seconds
+Result [shark-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2734) : 3.985969 seconds
+Result [turbot-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2734) : 3.804624 seconds
+Result [eel-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2734) : 3.726746 seconds
+Result [perch-0] : level-3 : parent(2031, 781, 2656) : (2109, 859, 2578) : 6.148407 seconds
+Result [marlin-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2578) : 3.744046 seconds
+Result [anchovy-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2578) : 3.836857 seconds
+Result [sardine-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2734) : 3.697096 seconds
+Warning: No xauth data; using fake authentication data for X11 forwarding.
+Result [swordfish-0] : level-3 : parent(2031, 781, 2656) : (2109, 703, 2578) : 3.714712 seconds
+Result [cod-0] : level-3 : parent(2031, 781, 2656) : (1953, 703, 2734) : 3.684939 seconds
+Result [herring-0] : level-3 : parent(2031, 781, 2656) : (1953, 859, 2578) : 4.07207 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1953, 703, 2734) 3.7051412 seconds
+...done.
+
+OPTIMAL : (1953, 703, 2734) 3.7051412 seconds : 11.245635299045192 GFlops/sec
+
+Creating tasks for parent (2343, 781, 2656) ...
+Result [anchovy-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2578) : 3.762875 seconds
+Result [sole-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2734) : 4.248885 seconds
+Result [herring-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2578) : 4.566918 seconds
+Result [cod-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2734) : 3.680459 seconds
+Result [tarpon-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2578) : 3.710085 seconds
+Result [sardine-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2734) : 3.763979 seconds
+Result [dorado-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2734) : 3.787946 seconds
+Result [blowfish-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2578) : 3.669499 seconds
+Result [eel-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2734) : 3.725314 seconds
+Result [perch-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2734) : 5.774547 seconds
+Result [grouper-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2578) : 3.943953 seconds
+Result [anchovy-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2578) : 3.661614 seconds
+Result [sole-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2734) : 3.953812 seconds
+Result [herring-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2734) : 4.125457 seconds
+Result [barracuda-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2578) : 3.676182 seconds
+Result [bonito-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2578) : 3.688512 seconds
+Result [halibut-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2578) : 3.73267 seconds
+Result [wahoo-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2578) : 3.732196 seconds
+Result [sardine-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2734) : 3.670647 seconds
+Result [swordfish-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2578) : 3.687373 seconds
+Result [mackerel-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2578) : 3.756084 seconds
+Result [blowfish-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2578) : 3.747864 seconds
+Result [dorado-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2578) : 3.867913 seconds
+Result [grouper-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2578) : 3.858343 seconds
+Result [anchovy-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2734) : 3.802194 seconds
+Result [sole-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2734) : 3.953045 seconds
+Result [flounder-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2734) : 3.70706 seconds
+Result [brill-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2578) : 3.87379 seconds
+Result [barracuda-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2734) : 3.734482 seconds
+Result [eel-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2578) : 3.71104 seconds
+Result [bonito-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2734) : 3.778834 seconds
+Result [cod-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2734) : 3.715985 seconds
+Result [perch-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2578) : 6.041047 seconds
+Result [herring-0] : level-3 : parent(2343, 781, 2656) : (2421, 859, 2734) : 4.601028 seconds
+Result [pollock-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2734) : 3.724248 seconds
+Result [shark-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2734) : 4.098876 seconds
+Result [tarpon-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2734) : 3.851471 seconds
+Result [char-0] : level-3 : parent(2343, 781, 2656) : (2265, 703, 2734) : 3.680644 seconds
+Result [marlin-0] : level-3 : parent(2343, 781, 2656) : (2265, 859, 2578) : 3.766572 seconds
+Result [turbot-0] : level-3 : parent(2343, 781, 2656) : (2421, 703, 2578) : 3.674477 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (2421, 703, 2578) 3.693149 seconds
+...done.
+
+OPTIMAL : (2421, 703, 2578) 3.693149 seconds : 11.282151536985555 GFlops/sec
+
+Creating tasks for parent (2343, 781, 2968) ...
+Result [barracuda-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 2890) : 3.765663 seconds
+Result [wahoo-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 2890) : 3.693376 seconds
+Result [char-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 3046) : 3.826343 seconds
+Result [grouper-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 2890) : 3.896688 seconds
+Result [eel-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 3046) : 3.709841 seconds
+Result [halibut-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 2890) : 3.74218 seconds
+Result [cod-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 3046) : 3.732717 seconds
+Result [perch-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 3046) : 5.832174 seconds
+Result [flounder-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 3046) : 3.729938 seconds
+Result [marlin-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 2890) : 3.725123 seconds
+Result [bonito-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 2890) : 3.706509 seconds
+Result [mackerel-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 2890) : 3.752752 seconds
+Result [barracuda-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 2890) : 3.710882 seconds
+Result [char-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 3046) : 3.744017 seconds
+Result [grouper-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 3046) : 3.949907 seconds
+Result [dorado-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 3046) : 3.697219 seconds
+Result [sardine-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 3046) : 3.73081 seconds
+Result [wahoo-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 3046) : 3.742277 seconds
+Result [cod-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 2890) : 3.736881 seconds
+Result [pollock-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 3046) : 3.728084 seconds
+Result [herring-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 2890) : 3.793225 seconds
+Result [bonito-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 2890) : 3.727278 seconds
+Result [eel-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 3046) : 3.741096 seconds
+Result [marlin-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 2890) : 3.751236 seconds
+Result [mackerel-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 3046) : 3.724814 seconds
+Result [perch-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 2890) : 6.005072 seconds
+Result [char-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 3046) : 3.707383 seconds
+Result [barracuda-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 3046) : 3.879082 seconds
+Result [grouper-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 3046) : 4.136382 seconds
+Result [brill-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 2890) : 3.702429 seconds
+Result [dorado-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 3046) : 3.704067 seconds
+Result [halibut-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 3046) : 3.693717 seconds
+Result [flounder-0] : level-3 : parent(2343, 781, 2968) : (2421, 859, 2890) : 3.733275 seconds
+Result [tarpon-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 2890) : 3.695218 seconds
+Result [sole-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 3046) : 3.988905 seconds
+Result [shark-0] : level-3 : parent(2343, 781, 2968) : (2265, 859, 3046) : 4.15129 seconds
+Result [turbot-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 2890) : 3.683818 seconds
+Result [swordfish-0] : level-3 : parent(2343, 781, 2968) : (2421, 703, 2890) : 3.70459 seconds
+Result [blowfish-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 2890) : 3.722838 seconds
+Result [anchovy-0] : level-3 : parent(2343, 781, 2968) : (2265, 703, 2890) : 3.854311 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (2421, 703, 2890) 3.6975768 seconds
+...done.
+
+OPTIMAL : (2421, 703, 2890) 3.6975768 seconds : 11.268641307644147 GFlops/sec
+
+Creating tasks for parent (4375, 625, 3125) ...
+Result [bonito-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 2812) : 3.835838 seconds
+Result [mackerel-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 2812) : 3.747654 seconds
+Result [blowfish-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 2812) : 3.675713 seconds
+Result [shark-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 3437) : 3.902767 seconds
+Result [grouper-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 2812) : 3.967669 seconds
+Result [sardine-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 3437) : 3.955284 seconds
+Result [sole-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 3437) : 4.017202 seconds
+Result [dorado-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 3437) : 3.727059 seconds
+Result [anchovy-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 2812) : 3.722241 seconds
+Result [wahoo-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 2812) : 3.719126 seconds
+Result [mackerel-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 3437) : 3.758602 seconds
+Result [swordfish-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 2812) : 3.676254 seconds
+Result [char-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 3437) : 3.735488 seconds
+Result [blowfish-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 3437) : 3.714377 seconds
+Result [bonito-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 2812) : 3.676945 seconds
+Result [shark-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 3437) : 3.820463 seconds
+Result [sardine-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 3437) : 3.724762 seconds
+Result [grouper-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 3437) : 4.131521 seconds
+Result [sole-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 2812) : 3.980542 seconds
+Result [barracuda-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 2812) : 3.707096 seconds
+Result [halibut-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 2812) : 3.759712 seconds
+Result [cod-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 3437) : 3.784288 seconds
+Result [perch-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 3437) : 5.932886 seconds
+Result [anchovy-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 2812) : 3.758011 seconds
+Result [mackerel-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 2812) : 3.733657 seconds
+Result [eel-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 3437) : 3.72113 seconds
+Result [marlin-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 2812) : 3.746149 seconds
+Result [flounder-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 3437) : 3.737702 seconds
+Result [swordfish-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 3437) : 3.80748 seconds
+Result [blowfish-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 3437) : 3.772262 seconds
+Result [bonito-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 3437) : 3.828902 seconds
+Result [shark-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 3437) : 4.022596 seconds
+Result [tarpon-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 2812) : 3.6794 seconds
+Result [wahoo-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 2812) : 3.686536 seconds
+Result [herring-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 2812) : 3.717168 seconds
+Result [pollock-0] : level-1 : parent(4375, 625, 3125) : (4062, 937, 3437) : 3.782984 seconds
+Result [char-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 3437) : 3.762031 seconds
+Result [brill-0] : level-1 : parent(4375, 625, 3125) : (4062, 312, 2812) : 3.76439 seconds
+Result [dorado-0] : level-1 : parent(4375, 625, 3125) : (4687, 937, 2812) : 3.707417 seconds
+Result [turbot-0] : level-1 : parent(4375, 625, 3125) : (4687, 312, 2812) : 3.846438 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (4687, 312, 2812) 3.7196326 seconds
+Selected : (4062, 312, 2812) 3.7410556 seconds
+Selected : (4062, 312, 3437) 3.7411334000000003 seconds
+...done.
+
+Creating tasks for parent (4687, 312, 2812) ...
+Result [barracuda-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2656) : 3.720365 seconds
+Result [halibut-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2656) : 3.66615 seconds
+Result [brill-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2656) : 3.696935 seconds
+Result [eel-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2968) : 3.747799 seconds
+Result [dorado-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2968) : 3.701976 seconds
+Result [swordfish-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2656) : 3.675749 seconds
+Result [pollock-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2968) : 3.704726 seconds
+Result [cod-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2968) : 3.852336 seconds
+Result [anchovy-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2656) : 3.682103 seconds
+Result [bonito-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2656) : 3.66896 seconds
+Result [char-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2968) : 3.706386 seconds
+Result [tarpon-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2656) : 3.689832 seconds
+Result [barracuda-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2656) : 3.674068 seconds
+Result [halibut-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2968) : 3.742319 seconds
+Result [sardine-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2968) : 3.675868 seconds
+Result [herring-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2656) : 3.763422 seconds
+Result [dorado-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2968) : 3.702814 seconds
+Result [swordfish-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2968) : 3.698949 seconds
+Result [pollock-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2656) : 3.712249 seconds
+Result [brill-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2968) : 3.743353 seconds
+Result [cod-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2656) : 3.712811 seconds
+Result [perch-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2968) : 5.47142 seconds
+Result [anchovy-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2656) : 3.662142 seconds
+Result [sole-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2968) : 3.933096 seconds
+Result [tarpon-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2968) : 3.725892 seconds
+Result [eel-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2968) : 3.854785 seconds
+Result [barracuda-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2968) : 3.712833 seconds
+Result [halibut-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2968) : 3.686209 seconds
+Result [flounder-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2968) : 3.83831 seconds
+Result [char-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2656) : 3.662304 seconds
+Result [sardine-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2968) : 3.751436 seconds
+Result [grouper-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2656) : 4.127333 seconds
+Result [herring-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2968) : 3.937632 seconds
+Result [marlin-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2656) : 3.700663 seconds
+Result [turbot-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2656) : 3.716334 seconds
+Result [bonito-0] : level-2 : parent(4687, 312, 2812) : (4843, 468, 2656) : 3.650533 seconds
+Result [blowfish-0] : level-2 : parent(4687, 312, 2812) : (4531, 156, 2656) : 3.727932 seconds
+Result [wahoo-0] : level-2 : parent(4687, 312, 2812) : (4843, 156, 2656) : 3.70417 seconds
+Result [mackerel-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2656) : 3.745651 seconds
+Result [shark-0] : level-2 : parent(4687, 312, 2812) : (4531, 468, 2968) : 4.051075 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (4843, 468, 2656) 3.6800078 seconds
+Selected : (4843, 156, 2656) 3.6920306 seconds
+Selected : (4531, 156, 2656) 3.699259 seconds
+...done.
+
+Creating tasks for parent (4843, 468, 2656) ...
+Result [barracuda-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2578) : 3.713202 seconds
+Result [swordfish-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2578) : 3.72663 seconds
+Result [anchovy-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2578) : 3.9001 seconds
+Result [herring-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2578) : 4.028244 seconds
+Result [halibut-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2578) : 3.672676 seconds
+Result [blowfish-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2578) : 3.666343 seconds
+Result [perch-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2734) : 5.467444 seconds
+Result [sardine-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2734) : 3.672044 seconds
+Result [flounder-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2734) : 3.696662 seconds
+Result [dorado-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2734) : 3.68107 seconds
+Result [barracuda-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2578) : 3.663991 seconds
+Result [swordfish-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2734) : 3.691994 seconds
+Result [anchovy-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2734) : 3.835881 seconds
+Result [herring-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2734) : 3.871555 seconds
+Result [brill-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2578) : 3.665098 seconds
+Result [tarpon-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2578) : 3.665454 seconds
+Result [blowfish-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2734) : 3.664632 seconds
+Result [halibut-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2734) : 3.710384 seconds
+Result [pollock-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2734) : 3.685145 seconds
+Result [turbot-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2578) : 3.667721 seconds
+Result [flounder-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2578) : 3.671323 seconds
+Result [swordfish-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2734) : 3.670539 seconds
+Result [barracuda-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2578) : 3.706626 seconds
+Result [anchovy-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2734) : 3.773279 seconds
+Result [herring-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2734) : 3.82287 seconds
+Result [marlin-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2578) : 3.697055 seconds
+Result [brill-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2734) : 3.675822 seconds
+Result [tarpon-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2734) : 3.699664 seconds
+Result [perch-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2578) : 5.477827 seconds
+Result [bonito-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2578) : 3.670191 seconds
+Result [char-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2734) : 3.691921 seconds
+Result [mackerel-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2578) : 3.695178 seconds
+Result [dorado-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2578) : 3.656689 seconds
+Result [sardine-0] : level-3 : parent(4843, 468, 2656) : (4921, 546, 2578) : 3.713688 seconds
+Result [shark-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2734) : 4.118516 seconds
+Result [eel-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2734) : 3.67874 seconds
+Warning: No xauth data; using fake authentication data for X11 forwarding.
+Result [grouper-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2578) : 3.821482 seconds
+Result [cod-0] : level-3 : parent(4843, 468, 2656) : (4765, 390, 2734) : 3.826488 seconds
+Result [wahoo-0] : level-3 : parent(4843, 468, 2656) : (4921, 390, 2578) : 3.826274 seconds
+Result [sole-0] : level-3 : parent(4843, 468, 2656) : (4765, 546, 2734) : 3.948485 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4921, 390, 2578) 3.710014 seconds
+...done.
+
+OPTIMAL : (4921, 390, 2578) 3.710014 seconds : 11.23086507669962 GFlops/sec
+
+Creating tasks for parent (4843, 156, 2656) ...
+Result [blowfish-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2578) : 3.685913 seconds
+Result [mackerel-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2578) : 3.662527 seconds
+Result [herring-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2578) : 3.867432 seconds
+Result [perch-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2734) : 5.345858 seconds
+Result [cod-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2734) : 3.741561 seconds
+Result [bonito-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2578) : 3.724178 seconds
+Result [sardine-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2734) : 3.681668 seconds
+Result [flounder-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2734) : 3.686633 seconds
+Result [shark-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2734) : 4.121343 seconds
+Result [eel-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2734) : 3.696427 seconds
+Result [wahoo-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2578) : 3.685157 seconds
+Result [pollock-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2734) : 3.700815 seconds
+Result [anchovy-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2578) : 3.751306 seconds
+Result [mackerel-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2734) : 3.721764 seconds
+Result [blowfish-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2578) : 3.85255 seconds
+Result [herring-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2734) : 3.877083 seconds
+Result [dorado-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2734) : 3.694323 seconds
+Result [barracuda-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2578) : 3.714343 seconds
+Result [swordfish-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2578) : 3.696795 seconds
+Result [grouper-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2578) : 3.80409 seconds
+Result [cod-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2734) : 3.719411 seconds
+Result [bonito-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2734) : 3.778879 seconds
+Result [shark-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2578) : 3.836436 seconds
+Result [perch-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2734) : 5.2712 seconds
+Result [halibut-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2578) : 3.653703 seconds
+Result [brill-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2578) : 3.847598 seconds
+Result [sardine-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2578) : 3.691837 seconds
+Result [anchovy-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2734) : 3.709256 seconds
+Result [eel-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2578) : 3.829661 seconds
+Result [mackerel-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2734) : 3.67128 seconds
+Result [herring-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2734) : 3.763991 seconds
+Result [marlin-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2578) : 3.658718 seconds
+Result [char-0] : level-3 : parent(4843, 156, 2656) : (4765, 78, 2734) : 3.689433 seconds
+Result [flounder-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2578) : 3.686301 seconds
+Result [pollock-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2734) : 3.837321 seconds
+Result [blowfish-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2734) : 3.715723 seconds
+Result [sole-0] : level-3 : parent(4843, 156, 2656) : (4765, 234, 2734) : 3.90194 seconds
+Result [wahoo-0] : level-3 : parent(4843, 156, 2656) : (4921, 234, 2578) : 3.67855 seconds
+Result [turbot-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2578) : 3.679316 seconds
+Result [tarpon-0] : level-3 : parent(4843, 156, 2656) : (4921, 78, 2578) : 3.722535 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4765, 78, 2734) 3.7016754 seconds
+...done.
+
+OPTIMAL : (4765, 78, 2734) 3.7016754 seconds : 11.256164348356062 GFlops/sec
+
+Creating tasks for parent (4531, 156, 2656) ...
+Result [bonito-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2578) : 3.778963 seconds
+Result [mackerel-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2578) : 3.672885 seconds
+Result [marlin-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2578) : 3.707688 seconds
+Result [tarpon-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2578) : 3.67743 seconds
+Result [dorado-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2734) : 3.743639 seconds
+Result [eel-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2734) : 3.715031 seconds
+Result [herring-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2578) : 3.755178 seconds
+Result [turbot-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2578) : 3.846045 seconds
+Result [bonito-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2578) : 3.713875 seconds
+Result [brill-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2578) : 3.67686 seconds
+Result [cod-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2734) : 3.715411 seconds
+Result [swordfish-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2578) : 3.734648 seconds
+Result [marlin-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2734) : 3.697813 seconds
+Result [mackerel-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2734) : 3.736816 seconds
+Result [barracuda-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2578) : 3.678392 seconds
+Result [blowfish-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2578) : 3.684858 seconds
+Result [halibut-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2578) : 3.668838 seconds
+Result [dorado-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2734) : 3.679867 seconds
+Result [herring-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2578) : 3.719445 seconds
+Result [turbot-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2578) : 3.671506 seconds
+Result [bonito-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2578) : 3.662162 seconds
+Result [brill-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2578) : 3.682225 seconds
+Result [eel-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2734) : 3.683119 seconds
+Result [sole-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2734) : 3.976299 seconds
+Result [tarpon-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2734) : 3.740188 seconds
+Result [shark-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2734) : 4.087669 seconds
+Result [swordfish-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2734) : 3.833402 seconds
+Result [mackerel-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2734) : 3.663634 seconds
+Result [marlin-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2734) : 3.697242 seconds
+Result [perch-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2734) : 5.505012 seconds
+Result [char-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2734) : 3.724479 seconds
+Result [flounder-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2734) : 3.71625 seconds
+Result [barracuda-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2734) : 3.683203 seconds
+Result [cod-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2578) : 3.671192 seconds
+Result [pollock-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2734) : 3.676476 seconds
+Result [wahoo-0] : level-3 : parent(4531, 156, 2656) : (4609, 78, 2578) : 3.681047 seconds
+Result [blowfish-0] : level-3 : parent(4531, 156, 2656) : (4609, 234, 2734) : 3.711876 seconds
+Result [grouper-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2578) : 4.111422 seconds
+Result [sardine-0] : level-3 : parent(4531, 156, 2656) : (4453, 234, 2734) : 3.717449 seconds
+Result [anchovy-0] : level-3 : parent(4531, 156, 2656) : (4453, 78, 2578) : 3.727777 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4609, 234, 2578) 3.6813059999999997 seconds
+...done.
+
+OPTIMAL : (4609, 234, 2578) 3.6813059999999997 seconds : 11.318446949714767 GFlops/sec
+
+Creating tasks for parent (4062, 312, 2812) ...
+Result [blowfish-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2656) : 3.672918 seconds
+Result [eel-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2968) : 3.715537 seconds
+Result [cod-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2968) : 3.705968 seconds
+Result [char-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2968) : 3.847767 seconds
+Result [perch-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2968) : 5.193305 seconds
+Result [barracuda-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2656) : 3.67735 seconds
+Result [anchovy-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2656) : 3.84135 seconds
+Result [flounder-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2968) : 3.843553 seconds
+Result [dorado-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2968) : 3.712539 seconds
+Result [shark-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2968) : 3.794501 seconds
+Result [blowfish-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2656) : 3.656959 seconds
+Result [eel-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2968) : 3.716064 seconds
+Result [char-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2968) : 3.691557 seconds
+Result [brill-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2656) : 3.676007 seconds
+Result [bonito-0] : level-2 : parent(4062, 312, 2812) : (3906, 156, 2656) : 3.676075 seconds
+Result [sardine-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2968) : 3.754714 seconds
+Result [cod-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2968) : 3.701122 seconds
+Result [barracuda-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2968) : 3.785622 seconds
+Result [anchovy-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2656) : 3.699943 seconds
+Result [perch-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2968) : 5.331231 seconds
+Result [swordfish-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2656) : 3.675975 seconds
+Result [dorado-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2656) : 3.756621 seconds
+Result [blowfish-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2656) : 3.711609 seconds
+Result [eel-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2968) : 3.679488 seconds
+Result [shark-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2656) : 4.079407 seconds
+Result [halibut-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2656) : 3.662954 seconds
+Result [pollock-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2968) : 3.723951 seconds
+Result [brill-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2968) : 3.689248 seconds
+Result [bonito-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2968) : 3.706606 seconds
+Result [flounder-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2656) : 3.665297 seconds
+Result [sardine-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2968) : 3.878198 seconds
+Result [char-0] : level-2 : parent(4062, 312, 2812) : (4218, 468, 2968) : 3.71969 seconds
+Result [marlin-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2656) : 3.721155 seconds
+Result [grouper-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2656) : 3.814159 seconds
+Result [mackerel-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2656) : 3.742962 seconds
+Result [herring-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2656) : 3.949489 seconds
+Result [turbot-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2656) : 3.690734 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [sole-0] : level-2 : parent(4062, 312, 2812) : (3906, 468, 2968) : 3.952609 seconds
+Result [wahoo-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2656) : 3.677526 seconds
+Result [tarpon-0] : level-2 : parent(4062, 312, 2812) : (4218, 156, 2656) : 3.696592 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (4218, 156, 2656) 3.6795572 seconds
+Selected : (3906, 156, 2656) 3.70874 seconds
+Selected : (4218, 468, 2968) 3.734646 seconds
+...done.
+
+Creating tasks for parent (4218, 156, 2656) ...
+Result [mackerel-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2578) : 3.674499 seconds
+Result [char-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2734) : 3.719803 seconds
+Result [wahoo-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2578) : 3.672468 seconds
+Result [bonito-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2578) : 3.864389 seconds
+Result [halibut-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2578) : 3.699569 seconds
+Result [brill-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2578) : 3.852421 seconds
+Result [sole-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2734) : 3.963653 seconds
+Result [cod-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2734) : 3.85462 seconds
+Result [swordfish-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2578) : 3.688698 seconds
+Result [dorado-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2734) : 3.872296 seconds
+Result [grouper-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2578) : 4.081626 seconds
+Result [shark-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2734) : 4.057078 seconds
+Result [blowfish-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2578) : 3.690019 seconds
+Result [herring-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2578) : 3.764953 seconds
+Result [mackerel-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2578) : 3.766168 seconds
+Result [wahoo-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2734) : 3.707886 seconds
+Result [bonito-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2734) : 3.686559 seconds
+Result [brill-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2734) : 3.716216 seconds
+Result [sole-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2578) : 3.992081 seconds
+Result [perch-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2734) : 5.445648 seconds
+Result [marlin-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2578) : 3.665364 seconds
+Result [pollock-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2734) : 3.679502 seconds
+Result [sardine-0] : level-3 : parent(4218, 156, 2656) : (4140, 234, 2734) : 3.80999 seconds
+Result [char-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2734) : 3.71643 seconds
+Result [cod-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2578) : 3.675822 seconds
+Result [dorado-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2578) : 3.696741 seconds
+Result [grouper-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2578) : 3.76982 seconds
+Result [shark-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2734) : 4.008128 seconds
+Result [barracuda-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2578) : 3.716849 seconds
+Result [turbot-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2578) : 3.730068 seconds
+Result [blowfish-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2734) : 3.700539 seconds
+Result [herring-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2734) : 3.860488 seconds
+Result [wahoo-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2734) : 3.67999 seconds
+Result [eel-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2734) : 3.713894 seconds
+Result [anchovy-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2578) : 3.814764 seconds
+Result [swordfish-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2578) : 3.702002 seconds
+Result [mackerel-0] : level-3 : parent(4218, 156, 2656) : (4296, 234, 2734) : 3.671545 seconds
+Result [flounder-0] : level-3 : parent(4218, 156, 2656) : (4140, 78, 2734) : 3.736584 seconds
+Result [halibut-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2734) : 3.705993 seconds
+Result [tarpon-0] : level-3 : parent(4218, 156, 2656) : (4296, 78, 2578) : 3.847494 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4296, 78, 2734) 3.7066168 seconds
+...done.
+
+OPTIMAL : (4296, 78, 2734) 3.7066168 seconds : 11.24115842421765 GFlops/sec
+
+Creating tasks for parent (3906, 156, 2656) ...
+Result [blowfish-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2578) : 3.724977 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2578) : 3.686873 seconds
+Result [herring-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2578) : 3.765866 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2734) : 3.695204 seconds
+Result [cod-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2734) : 3.718693 seconds
+Result [swordfish-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2578) : 3.674273 seconds
+Result [anchovy-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2578) : 3.871908 seconds
+Result [grouper-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2578) : 4.10989 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2734) : 4.241956 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2734) : 5.358067 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2578) : 3.6881 seconds
+Result [tarpon-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2578) : 3.687549 seconds
+Result [blowfish-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2578) : 3.728944 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2734) : 3.681078 seconds
+Result [herring-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2734) : 3.746786 seconds
+Result [sole-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2734) : 4.007613 seconds
+Result [sardine-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2734) : 3.671857 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2578) : 3.713521 seconds
+Result [turbot-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2578) : 3.767129 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2734) : 3.727275 seconds
+Result [swordfish-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2734) : 3.69548 seconds
+Result [anchovy-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2578) : 3.659286 seconds
+Result [grouper-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2578) : 4.118677 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2578) : 4.200385 seconds
+Result [halibut-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2578) : 3.659426 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2734) : 3.698063 seconds
+Result [marlin-0] : level-3 : parent(3906, 156, 2656) : (3828, 234, 2578) : 3.687359 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2578) : 3.677437 seconds
+Result [cod-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2734) : 3.687101 seconds
+Result [tarpon-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2734) : 3.842724 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2734) : 3.685204 seconds
+Result [blowfish-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2734) : 3.688673 seconds
+Result [herring-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2734) : 3.854231 seconds
+Result [sole-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2734) : 3.931492 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 2656) : (3984, 234, 2578) : 5.401607 seconds
+Result [flounder-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2734) : 3.686699 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2578) : 3.679849 seconds
+Result [char-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2734) : 3.724954 seconds
+Result [eel-0] : level-3 : parent(3906, 156, 2656) : (3828, 78, 2734) : 3.702887 seconds
+Result [wahoo-0] : level-3 : parent(3906, 156, 2656) : (3984, 78, 2578) : 3.7201 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3828, 78, 2734) 3.7056874 seconds
+...done.
+
+OPTIMAL : (3828, 78, 2734) 3.7056874 seconds : 11.243977748006122 GFlops/sec
+
+Creating tasks for parent (4218, 468, 2968) ...
+Result [dorado-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 3046) : 3.689165 seconds
+Result [bonito-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 2890) : 3.789968 seconds
+Result [tarpon-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 2890) : 3.748403 seconds
+Result [grouper-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 2890) : 4.126399 seconds
+Result [char-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 3046) : 3.717803 seconds
+Result [halibut-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 2890) : 3.714252 seconds
+Result [wahoo-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 2890) : 3.8477 seconds
+Result [herring-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 2890) : 3.879294 seconds
+Result [blowfish-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 2890) : 3.730137 seconds
+Result [sardine-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 3046) : 3.734398 seconds
+Result [marlin-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 2890) : 3.722856 seconds
+Result [anchovy-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 2890) : 3.716591 seconds
+Result [dorado-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 2890) : 3.698345 seconds
+Result [bonito-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 3046) : 3.676018 seconds
+Result [tarpon-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 3046) : 3.699718 seconds
+Result [grouper-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 3046) : 3.935043 seconds
+Result [perch-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 3046) : 5.517772 seconds
+Result [eel-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 3046) : 3.694528 seconds
+Result [cod-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 3046) : 3.694211 seconds
+Result [barracuda-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 2890) : 3.843163 seconds
+Result [halibut-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 3046) : 3.678983 seconds
+Result [char-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 3046) : 3.706566 seconds
+Result [wahoo-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 2890) : 3.68373 seconds
+Result [flounder-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 3046) : 3.738986 seconds
+Result [brill-0] : level-3 : parent(4218, 468, 2968) : (4140, 390, 2890) : 3.836905 seconds
+Result [sardine-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 2890) : 3.667216 seconds
+Result [blowfish-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 2890) : 3.725973 seconds
+Result [sole-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 3046) : 3.939881 seconds
+Result [marlin-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 2890) : 3.668482 seconds
+Result [herring-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 2890) : 3.670406 seconds
+Result [bonito-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 3046) : 3.732619 seconds
+Result [dorado-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 3046) : 3.729385 seconds
+Result [tarpon-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 3046) : 3.863074 seconds
+Result [grouper-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 3046) : 4.137822 seconds
+Result [turbot-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 2890) : 3.711484 seconds
+Result [anchovy-0] : level-3 : parent(4218, 468, 2968) : (4296, 546, 3046) : 3.761473 seconds
+Result [swordfish-0] : level-3 : parent(4218, 468, 2968) : (4296, 390, 2890) : 3.67178 seconds
+Result [pollock-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 3046) : 3.724222 seconds
+Result [shark-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 3046) : 3.970875 seconds
+Result [mackerel-0] : level-3 : parent(4218, 468, 2968) : (4140, 546, 2890) : 3.696056 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4296, 546, 2890) 3.6831614 seconds
+...done.
+
+OPTIMAL : (4296, 546, 2890) 3.6831614 seconds : 11.312745259185943 GFlops/sec
+
+Creating tasks for parent (4062, 312, 3437) ...
+Result [brill-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3281) : 3.752134 seconds
+Result [grouper-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3281) : 3.865953 seconds
+Result [herring-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3281) : 4.077598 seconds
+Result [anchovy-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3281) : 3.713815 seconds
+Result [halibut-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3281) : 3.754248 seconds
+Result [tarpon-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3281) : 3.737715 seconds
+Result [dorado-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3593) : 3.772516 seconds
+Result [bonito-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3281) : 3.862533 seconds
+Result [brill-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3281) : 3.69703 seconds
+Result [grouper-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3593) : 3.888131 seconds
+Result [herring-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3593) : 3.956373 seconds
+Result [cod-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3593) : 3.729596 seconds
+Result [flounder-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3593) : 3.761658 seconds
+Result [mackerel-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3281) : 3.74094 seconds
+Result [halibut-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3593) : 3.727122 seconds
+Result [perch-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3593) : 5.51297 seconds
+Result [barracuda-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3281) : 3.717416 seconds
+Result [sardine-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3593) : 3.724728 seconds
+Result [dorado-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3281) : 3.752746 seconds
+Result [anchovy-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3593) : 3.893017 seconds
+Result [bonito-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3281) : 3.741553 seconds
+Result [brill-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3281) : 3.722253 seconds
+Result [grouper-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3281) : 4.272223 seconds
+Result [herring-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3281) : 4.009524 seconds
+Result [eel-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3593) : 3.753884 seconds
+Result [pollock-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3593) : 3.738124 seconds
+Result [cod-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3593) : 3.74183 seconds
+Result [tarpon-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3593) : 3.769278 seconds
+Result [halibut-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3593) : 3.717552 seconds
+Result [swordfish-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3281) : 3.765908 seconds
+Result [flounder-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3593) : 3.75811 seconds
+Result [perch-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3593) : 5.532263 seconds
+Result [marlin-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3281) : 3.714598 seconds
+Result [sole-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3593) : 4.05912 seconds
+Result [mackerel-0] : level-2 : parent(4062, 312, 3437) : (4218, 468, 3593) : 3.737799 seconds
+Result [turbot-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3281) : 3.700146 seconds
+Result [shark-0] : level-2 : parent(4062, 312, 3437) : (3906, 468, 3593) : 4.159228 seconds
+Result [wahoo-0] : level-2 : parent(4062, 312, 3437) : (4218, 156, 3281) : 3.875419 seconds
+Result [char-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3593) : 3.746415 seconds
+Result [blowfish-0] : level-2 : parent(4062, 312, 3437) : (3906, 156, 3281) : 3.766512 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (3906, 156, 3593) 3.7528138 seconds
+Selected : (4218, 156, 3281) 3.7552436 seconds
+Selected : (3906, 156, 3281) 3.762482 seconds
+...done.
+
+Creating tasks for parent (3906, 156, 3593) ...
+Result [char-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3671) : 3.756132 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3515) : 3.741146 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3515) : 3.744984 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3671) : 3.906708 seconds
+Result [blowfish-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3515) : 3.761559 seconds
+Result [anchovy-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3515) : 3.774198 seconds
+Result [sole-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3671) : 3.914309 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3671) : 5.577785 seconds
+Result [cod-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3671) : 3.737029 seconds
+Result [halibut-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3515) : 3.720076 seconds
+Result [flounder-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3671) : 3.757283 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3671) : 3.753948 seconds
+Result [char-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3515) : 3.799764 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3671) : 4.166302 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3671) : 3.801986 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3515) : 3.766693 seconds
+Result [eel-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3671) : 3.801649 seconds
+Result [blowfish-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3671) : 3.762419 seconds
+Result [anchovy-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3671) : 3.82735 seconds
+Result [sole-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3515) : 4.012908 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 3593) : (3828, 78, 3671) : 3.753461 seconds
+Result [wahoo-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3515) : 3.733877 seconds
+Result [marlin-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3515) : 3.751329 seconds
+Result [cod-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3515) : 3.750599 seconds
+Result [halibut-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3515) : 3.768118 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3671) : 3.791484 seconds
+Result [char-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3671) : 3.905602 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3671) : 3.859623 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3671) : 3.756644 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3515) : 5.502907 seconds
+Result [swordfish-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3515) : 3.741463 seconds
+Result [grouper-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3515) : 3.84387 seconds
+Result [flounder-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3515) : 3.709019 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3671) : 3.81275 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 3593) : (3984, 234, 3671) : 3.898447 seconds
+Result [tarpon-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3515) : 3.897958 seconds
+Result [herring-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3515) : 3.929544 seconds
+Result [turbot-0] : level-3 : parent(3906, 156, 3593) : (3984, 78, 3515) : 3.896368 seconds
+Result [sardine-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3671) : 3.7404 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 3593) : (3828, 234, 3515) : 3.726695 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3828, 78, 3515) 3.7577160000000003 seconds
+...done.
+
+OPTIMAL : (3828, 78, 3515) 3.7577160000000003 seconds : 11.088295833603887 GFlops/sec
+
+Creating tasks for parent (4218, 156, 3281) ...
+Result [bonito-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3203) : 3.718061 seconds
+Result [cod-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3359) : 3.75738 seconds
+Result [halibut-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3203) : 3.704711 seconds
+Result [eel-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3359) : 3.903274 seconds
+Result [shark-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3359) : 3.915365 seconds
+Result [flounder-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3359) : 3.74978 seconds
+Result [anchovy-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3203) : 3.72299 seconds
+Result [grouper-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3203) : 3.860169 seconds
+Result [blowfish-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3203) : 3.74758 seconds
+Result [brill-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3203) : 3.720218 seconds
+Result [marlin-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3203) : 3.771203 seconds
+Result [barracuda-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3203) : 3.882906 seconds
+Result [bonito-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3203) : 3.755643 seconds
+Result [cod-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3359) : 3.728516 seconds
+Result [eel-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3359) : 3.743304 seconds
+Result [shark-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3359) : 4.147312 seconds
+Result [turbot-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3203) : 3.706436 seconds
+Result [halibut-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3359) : 3.729135 seconds
+Result [sole-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3359) : 4.002826 seconds
+Result [flounder-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3359) : 3.894889 seconds
+Result [perch-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3359) : 5.562413 seconds
+Result [dorado-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3359) : 3.74938 seconds
+Result [pollock-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3359) : 3.711524 seconds
+Result [sardine-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3359) : 3.872819 seconds
+Result [brill-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3203) : 3.692229 seconds
+Result [blowfish-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3203) : 3.751593 seconds
+Result [anchovy-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3203) : 3.760273 seconds
+Result [marlin-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3203) : 3.870919 seconds
+Result [cod-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3359) : 3.699525 seconds
+Result [barracuda-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3359) : 3.766536 seconds
+Result [eel-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3359) : 3.752724 seconds
+Result [shark-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3359) : 4.189328 seconds
+Result [herring-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3203) : 3.756864 seconds
+Result [wahoo-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3203) : 3.75397 seconds
+Result [grouper-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3203) : 3.830528 seconds
+Result [bonito-0] : level-3 : parent(4218, 156, 3281) : (4296, 234, 3359) : 3.792894 seconds
+Result [swordfish-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3203) : 3.716196 seconds
+Result [tarpon-0] : level-3 : parent(4218, 156, 3281) : (4296, 78, 3203) : 3.782655 seconds
+Result [char-0] : level-3 : parent(4218, 156, 3281) : (4140, 78, 3359) : 3.886402 seconds
+Result [mackerel-0] : level-3 : parent(4218, 156, 3281) : (4140, 234, 3203) : 3.769854 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4296, 78, 3203) 3.74298 seconds
+...done.
+
+OPTIMAL : (4296, 78, 3203) 3.74298 seconds : 11.131950121739004 GFlops/sec
+
+Creating tasks for parent (3906, 156, 3281) ...
+Result [char-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3359) : 3.754783 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3203) : 3.764998 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3203) : 3.879606 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3359) : 5.491976 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3203) : 3.716202 seconds
+Result [turbot-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3203) : 3.741787 seconds
+Result [halibut-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3203) : 3.717307 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3359) : 3.794086 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3359) : 3.926969 seconds
+Result [char-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3203) : 3.730567 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3359) : 3.747355 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3359) : 3.733892 seconds
+Result [eel-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3359) : 3.786514 seconds
+Result [turbot-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3359) : 3.706917 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3359) : 3.77026 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3359) : 3.762032 seconds
+Result [tarpon-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3203) : 3.725844 seconds
+Result [halibut-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3203) : 3.696983 seconds
+Result [herring-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3203) : 4.080422 seconds
+Result [dorado-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3203) : 3.73716 seconds
+Result [brill-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3203) : 3.689453 seconds
+Result [shark-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3203) : 4.142419 seconds
+Result [perch-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3359) : 5.53243 seconds
+Result [cod-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3359) : 3.732609 seconds
+Result [flounder-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3359) : 3.727212 seconds
+Result [sardine-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3359) : 3.872938 seconds
+Result [pollock-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3359) : 3.731329 seconds
+Result [char-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3203) : 3.717345 seconds
+Result [turbot-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3359) : 3.738059 seconds
+Result [mackerel-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3359) : 3.75507 seconds
+Result [bonito-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3359) : 3.699325 seconds
+Result [blowfish-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3203) : 3.720748 seconds
+Result [barracuda-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3203) : 3.75821 seconds
+Result [sole-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3359) : 3.953722 seconds
+Result [wahoo-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3203) : 3.712874 seconds
+Result [swordfish-0] : level-3 : parent(3906, 156, 3281) : (3984, 78, 3203) : 3.751624 seconds
+Result [eel-0] : level-3 : parent(3906, 156, 3281) : (3984, 234, 3359) : 3.756843 seconds
+Result [anchovy-0] : level-3 : parent(3906, 156, 3281) : (3828, 78, 3203) : 3.767164 seconds
+Result [marlin-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3203) : 3.732816 seconds
+Result [grouper-0] : level-3 : parent(3906, 156, 3281) : (3828, 234, 3203) : 3.798275 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3984, 78, 3203) 3.7325392 seconds
+...done.
+
+OPTIMAL : (3984, 78, 3203) 3.7325392 seconds : 11.163088834182012 GFlops/sec
+
+Creating tasks for parent (3125, 625, 3125) ...
+Result [anchovy-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 2812) : 3.677711 seconds
+Result [char-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 3437) : 3.803791 seconds
+Result [eel-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 3437) : 3.767759 seconds
+Result [mackerel-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 2812) : 3.902125 seconds
+Result [herring-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 2812) : 4.740318 seconds
+Result [bonito-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 2812) : 3.672117 seconds
+Result [dorado-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 3437) : 3.895906 seconds
+Result [sole-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 3437) : 4.023086 seconds
+Result [shark-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 3437) : 4.209494 seconds
+Result [brill-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 2812) : 3.708064 seconds
+Result [swordfish-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 2812) : 3.678659 seconds
+Result [flounder-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 3437) : 3.741888 seconds
+Result [anchovy-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 2812) : 3.679614 seconds
+Result [char-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 3437) : 3.738546 seconds
+Result [eel-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 3437) : 3.756685 seconds
+Result [mackerel-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 3437) : 3.726147 seconds
+Result [herring-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 3437) : 3.996638 seconds
+Result [barracuda-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 2812) : 3.709894 seconds
+Result [pollock-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 3437) : 3.781189 seconds
+Result [bonito-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 3437) : 3.753115 seconds
+Result [dorado-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 2812) : 3.758362 seconds
+Result [shark-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 2812) : 3.948926 seconds
+Result [sole-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 2812) : 4.171719 seconds
+Result [wahoo-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 2812) : 3.704391 seconds
+Result [perch-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 3437) : 5.971884 seconds
+Result [grouper-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 2812) : 4.096678 seconds
+Result [flounder-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 3437) : 3.751644 seconds
+Result [anchovy-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 3437) : 3.785346 seconds
+Result [mackerel-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 3437) : 3.763525 seconds
+Result [turbot-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 2812) : 3.706792 seconds
+Result [halibut-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 2812) : 3.780113 seconds
+Result [swordfish-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 2812) : 3.747223 seconds
+Result [char-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 3437) : 3.751919 seconds
+Result [eel-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 3437) : 3.764949 seconds
+Result [blowfish-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 2812) : 3.678568 seconds
+Result [cod-0] : level-1 : parent(3125, 625, 3125) : (2812, 312, 3437) : 3.718921 seconds
+Result [brill-0] : level-1 : parent(3125, 625, 3125) : (3437, 937, 2812) : 3.837628 seconds
+Result [tarpon-0] : level-1 : parent(3125, 625, 3125) : (3437, 312, 2812) : 3.685756 seconds
+Result [marlin-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 2812) : 3.904781 seconds
+Result [sardine-0] : level-1 : parent(3125, 625, 3125) : (2812, 937, 3437) : 3.943766 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (2812, 312, 2812) 3.6892708 seconds
+Selected : (3437, 312, 2812) 3.6910424 seconds
+Selected : (3437, 937, 3437) 3.7634766 seconds
+...done.
+
+Creating tasks for parent (2812, 312, 2812) ...
+Result [anchovy-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2656) : 3.698429 seconds
+Result [eel-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2968) : 3.706323 seconds
+Result [char-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2968) : 3.688291 seconds
+Result [turbot-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2656) : 3.673703 seconds
+Result [grouper-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2656) : 4.110334 seconds
+Result [brill-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2656) : 3.68601 seconds
+Result [flounder-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2968) : 3.713676 seconds
+Result [halibut-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2656) : 3.693264 seconds
+Result [swordfish-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2656) : 3.673332 seconds
+Result [bonito-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2656) : 3.689241 seconds
+Result [sardine-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2968) : 3.840045 seconds
+Result [anchovy-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2656) : 3.658139 seconds
+Result [char-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2968) : 3.671749 seconds
+Result [grouper-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2968) : 4.130401 seconds
+Result [mackerel-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2656) : 3.674031 seconds
+Result [blowfish-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2656) : 3.729435 seconds
+Result [herring-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2656) : 3.887374 seconds
+Result [halibut-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2656) : 3.712189 seconds
+Result [eel-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2968) : 3.670364 seconds
+Result [brill-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2968) : 3.84102 seconds
+Result [perch-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2968) : 5.345176 seconds
+Result [dorado-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2968) : 3.68791 seconds
+Result [pollock-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2968) : 3.724116 seconds
+Result [marlin-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2656) : 3.832855 seconds
+Result [flounder-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2656) : 3.68119 seconds
+Result [bonito-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2656) : 3.678123 seconds
+Result [anchovy-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2968) : 3.675828 seconds
+Result [char-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2968) : 3.671561 seconds
+Result [sardine-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2656) : 3.795576 seconds
+Result [grouper-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2968) : 4.137388 seconds
+Result [barracuda-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2656) : 3.696262 seconds
+Result [cod-0] : level-2 : parent(2812, 312, 2812) : (2656, 156, 2968) : 3.683489 seconds
+Result [mackerel-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2968) : 3.671789 seconds
+Result [shark-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2968) : 3.940214 seconds
+Result [turbot-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2968) : 3.721046 seconds
+Result [blowfish-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2968) : 3.713315 seconds
+Result [tarpon-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2656) : 3.70656 seconds
+Result [sole-0] : level-2 : parent(2812, 312, 2812) : (2656, 468, 2968) : 3.927021 seconds
+Result [swordfish-0] : level-2 : parent(2812, 312, 2812) : (2968, 468, 2656) : 3.70434 seconds
+Result [wahoo-0] : level-2 : parent(2812, 312, 2812) : (2968, 156, 2656) : 3.675229 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (2968, 156, 2656) 3.6773926 seconds
+Selected : (2656, 156, 2968) 3.6959378 seconds
+Selected : (2656, 156, 2656) 3.6998754 seconds
+...done.
+
+Creating tasks for parent (2968, 156, 2656) ...
+Result [cod-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2734) : 3.715165 seconds
+Result [flounder-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2734) : 3.720436 seconds
+Result [marlin-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2578) : 3.66876 seconds
+Result [grouper-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2578) : 3.853271 seconds
+Result [eel-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2734) : 3.842854 seconds
+Result [sardine-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2734) : 3.823821 seconds
+Result [pollock-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2734) : 3.681048 seconds
+Result [bonito-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2578) : 3.667294 seconds
+Result [blowfish-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2578) : 3.761157 seconds
+Result [brill-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2578) : 3.672629 seconds
+Result [shark-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2734) : 3.771172 seconds
+Result [tarpon-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2578) : 3.77724 seconds
+Result [turbot-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2578) : 3.669148 seconds
+Result [barracuda-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2578) : 3.71778 seconds
+Result [anchovy-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2578) : 3.839629 seconds
+Result [cod-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2578) : 3.685022 seconds
+Result [flounder-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2734) : 3.700974 seconds
+Result [sardine-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2734) : 3.689488 seconds
+Result [swordfish-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2578) : 3.671737 seconds
+Result [char-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2734) : 3.741565 seconds
+Result [pollock-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2578) : 3.658739 seconds
+Result [bonito-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2578) : 3.649859 seconds
+Result [brill-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2578) : 3.665463 seconds
+Result [eel-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2734) : 3.729576 seconds
+Result [shark-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2578) : 3.86648 seconds
+Result [perch-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2734) : 5.398705 seconds
+Result [turbot-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2734) : 3.651821 seconds
+Result [sole-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2734) : 3.906029 seconds
+Result [marlin-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2734) : 3.710277 seconds
+Result [barracuda-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2734) : 3.70133 seconds
+Result [anchovy-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2734) : 3.708731 seconds
+Result [tarpon-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2734) : 3.72927 seconds
+Result [cod-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2734) : 3.690789 seconds
+Result [mackerel-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2578) : 3.687392 seconds
+Result [grouper-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2734) : 3.826672 seconds
+Result [halibut-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2578) : 3.66094 seconds
+Result [blowfish-0] : level-3 : parent(2968, 156, 2656) : (3046, 234, 2578) : 3.684408 seconds
+Result [wahoo-0] : level-3 : parent(2968, 156, 2656) : (3046, 78, 2578) : 3.686323 seconds
+Result [dorado-0] : level-3 : parent(2968, 156, 2656) : (2890, 78, 2734) : 3.711008 seconds
+Result [herring-0] : level-3 : parent(2968, 156, 2656) : (2890, 234, 2578) : 3.753195 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3046, 234, 2734) 3.6963882 seconds
+...done.
+
+OPTIMAL : (3046, 234, 2734) 3.6963882 seconds : 11.272264819660085 GFlops/sec
+
+Creating tasks for parent (2656, 156, 2968) ...
+Result [bonito-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 2890) : 3.682681 seconds
+Result [eel-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 3046) : 3.701114 seconds
+Result [flounder-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 3046) : 3.703288 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 2890) : 3.751453 seconds
+Result [halibut-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 2890) : 3.695562 seconds
+Result [wahoo-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 2890) : 3.676202 seconds
+Result [perch-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 3046) : 5.25409 seconds
+Result [cod-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 3046) : 3.728731 seconds
+Result [marlin-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 2890) : 3.714004 seconds
+Result [dorado-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 3046) : 3.729337 seconds
+Result [bonito-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 2890) : 3.685996 seconds
+Result [eel-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 3046) : 3.698003 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 3046) : 3.726397 seconds
+Result [brill-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 2890) : 3.687919 seconds
+Result [pollock-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 3046) : 3.697473 seconds
+Result [tarpon-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 2890) : 3.696551 seconds
+Result [mackerel-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 2890) : 3.842981 seconds
+Result [halibut-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 3046) : 3.684995 seconds
+Result [flounder-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 3046) : 3.713155 seconds
+Result [char-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 3046) : 3.712079 seconds
+Result [blowfish-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 2890) : 3.691844 seconds
+Result [sole-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 3046) : 3.956268 seconds
+Result [wahoo-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 3046) : 3.714425 seconds
+Result [bonito-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 2890) : 3.662987 seconds
+Result [dorado-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 2890) : 3.7773 seconds
+Result [eel-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 3046) : 3.746263 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 3046) : 4.03523 seconds
+Result [perch-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 2890) : 5.482463 seconds
+Result [barracuda-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 2890) : 3.722263 seconds
+Result [anchovy-0] : level-3 : parent(2656, 156, 2968) : (2578, 78, 2890) : 3.744541 seconds
+Result [swordfish-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 2890) : 3.74306 seconds
+Result [brill-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 3046) : 3.738295 seconds
+Result [pollock-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 3046) : 3.684127 seconds
+Result [tarpon-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 3046) : 3.704547 seconds
+Result [grouper-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 2890) : 3.880878 seconds
+Result [cod-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 2890) : 3.690552 seconds
+Result [shark-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 3046) : 4.143909 seconds
+Result [turbot-0] : level-3 : parent(2656, 156, 2968) : (2734, 78, 2890) : 3.731177 seconds
+Result [sardine-0] : level-3 : parent(2656, 156, 2968) : (2578, 234, 3046) : 3.841314 seconds
+Result [marlin-0] : level-3 : parent(2656, 156, 2968) : (2734, 234, 2890) : 3.683439 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (2578, 78, 2890) 3.7058496 seconds
+...done.
+
+OPTIMAL : (2578, 78, 2890) 3.7058496 seconds : 11.24348561438291 GFlops/sec
+
+Creating tasks for parent (2656, 156, 2656) ...
+Result [bonito-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2578) : 3.687066 seconds
+Result [blowfish-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2578) : 3.682353 seconds
+Result [wahoo-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2578) : 3.721498 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2578) : 3.872367 seconds
+Result [grouper-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2578) : 4.101625 seconds
+Result [char-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2734) : 3.715444 seconds
+Result [barracuda-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2578) : 3.672108 seconds
+Result [marlin-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2578) : 3.676823 seconds
+Result [sole-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2734) : 3.859175 seconds
+Result [tarpon-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2578) : 3.675046 seconds
+Result [cod-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2734) : 3.708988 seconds
+Result [anchovy-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2578) : 3.857473 seconds
+Result [bonito-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2578) : 3.669208 seconds
+Result [blowfish-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2734) : 3.702427 seconds
+Result [wahoo-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2734) : 3.67234 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2734) : 3.948545 seconds
+Result [grouper-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2734) : 3.90501 seconds
+Result [eel-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2734) : 3.68268 seconds
+Result [halibut-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2578) : 3.649467 seconds
+Result [swordfish-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2578) : 3.678509 seconds
+Result [mackerel-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2578) : 3.828677 seconds
+Result [barracuda-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2578) : 3.644418 seconds
+Result [marlin-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2578) : 3.673084 seconds
+Result [char-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2734) : 3.823889 seconds
+Result [sole-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2578) : 3.961432 seconds
+Result [flounder-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2734) : 3.669177 seconds
+Result [brill-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2578) : 3.678018 seconds
+Result [tarpon-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2578) : 3.692874 seconds
+Result [anchovy-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2734) : 3.661791 seconds
+Result [bonito-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2734) : 3.651634 seconds
+Result [blowfish-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2734) : 3.831798 seconds
+Result [herring-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2734) : 4.001322 seconds
+Result [shark-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2734) : 3.904883 seconds
+Result [cod-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2578) : 3.667269 seconds
+Result [wahoo-0] : level-3 : parent(2656, 156, 2656) : (2734, 234, 2734) : 3.719577 seconds
+Result [pollock-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2734) : 3.67616 seconds
+Result [sardine-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2734) : 3.664808 seconds
+Result [turbot-0] : level-3 : parent(2656, 156, 2656) : (2734, 78, 2578) : 3.838806 seconds
+Result [perch-0] : level-3 : parent(2656, 156, 2656) : (2578, 234, 2734) : 5.418871 seconds
+Result [dorado-0] : level-3 : parent(2656, 156, 2656) : (2578, 78, 2734) : 3.816776 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (2578, 78, 2578) 3.7154036 seconds
+...done.
+
+OPTIMAL : (2578, 78, 2578) 3.7154036 seconds : 11.21457347639612 GFlops/sec
+
+Creating tasks for parent (3437, 312, 2812) ...
+Result [eel-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2968) : 3.687203 seconds
+Result [char-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2968) : 3.689189 seconds
+Result [cod-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2968) : 3.74984 seconds
+Result [tarpon-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2656) : 3.742102 seconds
+Result [flounder-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2968) : 3.705367 seconds
+Result [mackerel-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2656) : 3.669028 seconds
+Result [grouper-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2656) : 3.85421 seconds
+Result [perch-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2968) : 5.420797 seconds
+Result [blowfish-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2656) : 3.665069 seconds
+Result [barracuda-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2656) : 3.666694 seconds
+Result [herring-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2656) : 3.712622 seconds
+Result [marlin-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2656) : 3.711097 seconds
+Result [eel-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2656) : 3.677542 seconds
+Result [cod-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2968) : 3.713423 seconds
+Result [tarpon-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2968) : 3.698355 seconds
+Result [halibut-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2656) : 3.675902 seconds
+Result [turbot-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2656) : 3.673461 seconds
+Result [char-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2968) : 3.707107 seconds
+Result [shark-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2968) : 3.933215 seconds
+Result [mackerel-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2968) : 3.70678 seconds
+Result [grouper-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2656) : 3.753054 seconds
+Result [dorado-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2968) : 3.702177 seconds
+Result [blowfish-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2656) : 3.679971 seconds
+Result [flounder-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2968) : 3.689968 seconds
+Result [herring-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2656) : 3.761301 seconds
+Result [marlin-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2968) : 3.740792 seconds
+Result [eel-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2968) : 3.695139 seconds
+Result [tarpon-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2968) : 3.675297 seconds
+Result [wahoo-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2656) : 3.673101 seconds
+Result [barracuda-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2656) : 3.677096 seconds
+Result [halibut-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2968) : 3.670763 seconds
+Result [cod-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2968) : 3.71022 seconds
+Result [bonito-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2656) : 3.692855 seconds
+Result [sole-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2968) : 3.934897 seconds
+Result [perch-0] : level-2 : parent(3437, 312, 2812) : (3593, 468, 2656) : 5.098636 seconds
+Result [swordfish-0] : level-2 : parent(3437, 312, 2812) : (3593, 156, 2656) : 3.701555 seconds
+Result [anchovy-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2656) : 3.826714 seconds
+Result [sardine-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2968) : 3.837849 seconds
+Result [pollock-0] : level-2 : parent(3437, 312, 2812) : (3281, 468, 2968) : 3.753678 seconds
+Result [brill-0] : level-2 : parent(3437, 312, 2812) : (3281, 156, 2656) : 3.808051 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (3593, 156, 2656) 3.6935522 seconds
+Selected : (3593, 468, 2968) 3.6984422 seconds
+Selected : (3593, 156, 2968) 3.7031266 seconds
+...done.
+
+Creating tasks for parent (3593, 156, 2656) ...
+Result [cod-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2734) : 3.69839 seconds
+Result [bonito-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2578) : 3.680195 seconds
+Result [blowfish-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2578) : 3.705032 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2734) : 3.701071 seconds
+Result [perch-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2734) : 5.251081 seconds
+Result [tarpon-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2578) : 3.69225 seconds
+Result [brill-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2578) : 3.831581 seconds
+Result [grouper-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2578) : 4.136206 seconds
+Result [halibut-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2578) : 3.664315 seconds
+Result [pollock-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2734) : 3.681059 seconds
+Result [barracuda-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2578) : 3.710246 seconds
+Result [cod-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2578) : 3.700337 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2734) : 3.858329 seconds
+Result [dorado-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2734) : 3.755482 seconds
+Result [sardine-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2734) : 3.778291 seconds
+Result [anchovy-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2578) : 3.844993 seconds
+Result [bonito-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2734) : 3.709809 seconds
+Result [blowfish-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2734) : 3.742236 seconds
+Result [tarpon-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2734) : 3.729828 seconds
+Result [brill-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2578) : 3.671277 seconds
+Result [grouper-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2578) : 3.937014 seconds
+Result [perch-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2734) : 5.386616 seconds
+Result [char-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2734) : 3.692282 seconds
+Result [herring-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2578) : 3.7698 seconds
+Result [turbot-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2578) : 3.792591 seconds
+Result [flounder-0] : level-3 : parent(3593, 156, 2656) : (3515, 78, 2734) : 3.846265 seconds
+Result [halibut-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2578) : 3.675101 seconds
+Result [barracuda-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2578) : 3.78042 seconds
+Result [cod-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2734) : 3.656881 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2734) : 3.749023 seconds
+Result [marlin-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2578) : 3.661721 seconds
+Result [mackerel-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2578) : 3.709833 seconds
+Result [sole-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2734) : 3.847097 seconds
+Result [pollock-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2578) : 3.661243 seconds
+Result [dorado-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2734) : 3.698104 seconds
+Result [sardine-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2734) : 3.743981 seconds
+Result [anchovy-0] : level-3 : parent(3593, 156, 2656) : (3671, 234, 2734) : 3.727441 seconds
+Result [shark-0] : level-3 : parent(3593, 156, 2656) : (3515, 234, 2734) : 4.114782 seconds
+Result [swordfish-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2578) : 3.718741 seconds
+Result [wahoo-0] : level-3 : parent(3593, 156, 2656) : (3671, 78, 2578) : 3.692898 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3671, 234, 2734) 3.715086 seconds
+...done.
+
+OPTIMAL : (3671, 234, 2734) 3.715086 seconds : 11.215532202125782 GFlops/sec
+
+Creating tasks for parent (3593, 468, 2968) ...
+Result [anchovy-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 2890) : 3.700202 seconds
+Result [bonito-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 2890) : 3.687354 seconds
+Result [eel-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 3046) : 3.854111 seconds
+Result [flounder-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 3046) : 3.846822 seconds
+Result [wahoo-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 2890) : 3.665269 seconds
+Result [marlin-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 2890) : 3.717157 seconds
+Result [perch-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 3046) : 5.484804 seconds
+Result [cod-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 3046) : 3.711808 seconds
+Result [pollock-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 3046) : 3.737559 seconds
+Result [anchovy-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 2890) : 3.693402 seconds
+Result [bonito-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 3046) : 3.701962 seconds
+Result [flounder-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 3046) : 3.68375 seconds
+Result [eel-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 3046) : 3.745954 seconds
+Result [grouper-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 2890) : 4.125107 seconds
+Result [char-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 3046) : 3.703608 seconds
+Result [halibut-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 2890) : 3.670786 seconds
+Result [marlin-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 3046) : 3.733279 seconds
+Result [shark-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 3046) : 4.2678 seconds
+Result [mackerel-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 2890) : 3.838771 seconds
+Result [sole-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 3046) : 3.959302 seconds
+Result [cod-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 2890) : 3.723535 seconds
+Result [wahoo-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 3046) : 3.70761 seconds
+Result [anchovy-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 2890) : 3.680241 seconds
+Result [bonito-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 2890) : 3.676022 seconds
+Result [flounder-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 3046) : 3.691998 seconds
+Result [grouper-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 3046) : 4.142578 seconds
+Result [perch-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 2890) : 5.301733 seconds
+Result [blowfish-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 2890) : 3.711971 seconds
+Result [turbot-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 2890) : 3.760335 seconds
+Result [pollock-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 2890) : 3.671979 seconds
+Result [char-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 3046) : 3.85582 seconds
+Result [eel-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 3046) : 3.708016 seconds
+Result [swordfish-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 2890) : 3.715878 seconds
+Result [brill-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 2890) : 3.845747 seconds
+Result [halibut-0] : level-3 : parent(3593, 468, 2968) : (3671, 546, 3046) : 3.730566 seconds
+Result [barracuda-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 2890) : 3.844694 seconds
+Result [herring-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 2890) : 4.006602 seconds
+Result [sardine-0] : level-3 : parent(3593, 468, 2968) : (3515, 546, 3046) : 3.691034 seconds
+Result [dorado-0] : level-3 : parent(3593, 468, 2968) : (3515, 390, 3046) : 3.692708 seconds
+Result [tarpon-0] : level-3 : parent(3593, 468, 2968) : (3671, 390, 2890) : 3.756468 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3671, 390, 3046) 3.714511 seconds
+...done.
+
+OPTIMAL : (3671, 390, 3046) 3.714511 seconds : 11.217268347480104 GFlops/sec
+
+Creating tasks for parent (3593, 156, 2968) ...
+Result [anchovy-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 2890) : 3.701982 seconds
+Result [pollock-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 3046) : 3.729517 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 3046) : 3.863862 seconds
+Result [bonito-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 2890) : 3.695507 seconds
+Result [brill-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 2890) : 3.705603 seconds
+Result [wahoo-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 2890) : 3.709308 seconds
+Result [swordfish-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 2890) : 3.728925 seconds
+Result [flounder-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 3046) : 3.863008 seconds
+Result [sole-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 3046) : 3.84716 seconds
+Result [herring-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 2890) : 3.907972 seconds
+Result [anchovy-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 2890) : 3.735039 seconds
+Result [pollock-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 3046) : 3.720686 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 3046) : 3.714914 seconds
+Result [char-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 3046) : 3.733751 seconds
+Result [halibut-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 2890) : 3.708149 seconds
+Result [grouper-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 2890) : 3.839077 seconds
+Result [bonito-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 3046) : 3.713189 seconds
+Result [wahoo-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 3046) : 3.735761 seconds
+Result [dorado-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 3046) : 3.78627 seconds
+Result [cod-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 3046) : 3.705945 seconds
+Result [blowfish-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 2890) : 3.84307 seconds
+Result [brill-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 3046) : 3.699099 seconds
+Result [swordfish-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 2890) : 3.852669 seconds
+Result [flounder-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 2890) : 3.72734 seconds
+Result [anchovy-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 2890) : 3.673167 seconds
+Result [sole-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 2890) : 3.976995 seconds
+Result [herring-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 2890) : 3.94787 seconds
+Result [eel-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 3046) : 3.694044 seconds
+Result [pollock-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 3046) : 3.858221 seconds
+Result [mackerel-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 2890) : 3.684132 seconds
+Result [halibut-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 3046) : 3.693826 seconds
+Result [char-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 3046) : 3.704751 seconds
+Result [grouper-0] : level-3 : parent(3593, 156, 2968) : (3671, 234, 3046) : 3.838692 seconds
+Result [perch-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 3046) : 5.345613 seconds
+Result [turbot-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 2890) : 3.722141 seconds
+Result [shark-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 3046) : 4.160966 seconds
+Result [barracuda-0] : level-3 : parent(3593, 156, 2968) : (3515, 78, 2890) : 3.724696 seconds
+Result [tarpon-0] : level-3 : parent(3593, 156, 2968) : (3671, 78, 2890) : 3.718138 seconds
+Result [sardine-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 3046) : 3.695442 seconds
+Result [marlin-0] : level-3 : parent(3593, 156, 2968) : (3515, 234, 2890) : 3.709017 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3671, 78, 3046) 3.7167298 seconds
+...done.
+
+OPTIMAL : (3671, 78, 3046) 3.7167298 seconds : 11.210571902931083 GFlops/sec
+
+Creating tasks for parent (3437, 937, 3437) ...
+Result [bonito-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3281) : 3.72931 seconds
+Result [brill-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3281) : 3.733247 seconds
+Result [anchovy-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3281) : 3.774326 seconds
+Result [pollock-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3593) : 3.903463 seconds
+Result [barracuda-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3281) : 3.763706 seconds
+Result [sardine-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3593) : 3.839416 seconds
+Result [herring-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3281) : 4.89026 seconds
+Result [wahoo-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3281) : 3.722315 seconds
+Result [swordfish-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3281) : 3.71802 seconds
+Result [dorado-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3593) : 3.796739 seconds
+Result [mackerel-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3281) : 3.820073 seconds
+Result [eel-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3593) : 3.923246 seconds
+Result [bonito-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3281) : 3.734887 seconds
+Result [brill-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3593) : 3.743265 seconds
+Result [anchovy-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3593) : 3.811237 seconds
+Result [pollock-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3593) : 3.773912 seconds
+Result [perch-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3593) : 6.502776 seconds
+Result [flounder-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3593) : 3.779445 seconds
+Result [marlin-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3281) : 3.852664 seconds
+Result [barracuda-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3593) : 3.750292 seconds
+Result [sole-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3593) : 4.130597 seconds
+Result [sardine-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3593) : 3.764049 seconds
+Result [tarpon-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3281) : 3.727684 seconds
+Result [grouper-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3281) : 3.997906 seconds
+Result [shark-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3593) : 4.009693 seconds
+Result [wahoo-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3281) : 3.741798 seconds
+Result [swordfish-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3281) : 3.843261 seconds
+Result [dorado-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3281) : 3.811201 seconds
+Result [herring-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3281) : 4.79922 seconds
+Result [eel-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3593) : 3.844269 seconds
+Result [bonito-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3593) : 3.862142 seconds
+Result [anchovy-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3593) : 3.916248 seconds
+Result [pollock-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3593) : 3.874818 seconds
+Result [turbot-0] : level-2 : parent(3437, 937, 3437) : (3593, 781, 3281) : 3.779886 seconds
+Result [blowfish-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3281) : 3.802896 seconds
+Result [mackerel-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3281) : 3.963933 seconds
+Result [brill-0] : level-2 : parent(3437, 937, 3437) : (3593, 1093, 3593) : 3.900735 seconds
+Result [char-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3593) : 3.766934 seconds
+Result [cod-0] : level-2 : parent(3437, 937, 3437) : (3281, 781, 3593) : 3.762111 seconds
+Result [halibut-0] : level-2 : parent(3437, 937, 3437) : (3281, 1093, 3281) : 3.824653 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (3593, 781, 3281) 3.7365584 seconds
+Selected : (3281, 781, 3281) 3.760697 seconds
+Selected : (3593, 781, 3593) 3.768551 seconds
+...done.
+
+Creating tasks for parent (3593, 781, 3281) ...
+Result [char-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3359) : 3.738249 seconds
+Result [anchovy-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3203) : 3.784575 seconds
+Result [brill-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3203) : 3.750925 seconds
+Result [wahoo-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3203) : 3.771563 seconds
+Result [shark-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3359) : 3.934942 seconds
+Result [marlin-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3203) : 3.732567 seconds
+Result [grouper-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3203) : 3.867272 seconds
+Result [dorado-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3359) : 3.830954 seconds
+Result [bonito-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3203) : 3.739971 seconds
+Result [pollock-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3359) : 3.797314 seconds
+Result [char-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3203) : 3.740744 seconds
+Result [anchovy-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3359) : 3.769786 seconds
+Result [brill-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3359) : 3.741802 seconds
+Result [wahoo-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3359) : 3.768479 seconds
+Result [shark-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3359) : 4.182318 seconds
+Result [flounder-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3359) : 3.72274 seconds
+Result [halibut-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3203) : 3.721809 seconds
+Result [sardine-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3359) : 3.795811 seconds
+Result [dorado-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3203) : 3.719495 seconds
+Result [marlin-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3359) : 3.895384 seconds
+Result [barracuda-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3203) : 3.718148 seconds
+Result [bonito-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3203) : 3.767607 seconds
+Result [pollock-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3203) : 3.743359 seconds
+Result [char-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3203) : 3.796306 seconds
+Result [anchovy-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3359) : 3.770938 seconds
+Result [grouper-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3203) : 4.137144 seconds
+Result [wahoo-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3359) : 3.791766 seconds
+Result [shark-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3359) : 4.210345 seconds
+Result [mackerel-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3203) : 3.736449 seconds
+Result [cod-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3359) : 3.750367 seconds
+Result [turbot-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3203) : 3.731629 seconds
+Result [perch-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3359) : 5.86396 seconds
+Result [flounder-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3359) : 3.744981 seconds
+Result [sole-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3359) : 3.954184 seconds
+Result [brill-0] : level-3 : parent(3593, 781, 3281) : (3671, 859, 3359) : 3.735346 seconds
+Result [eel-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3359) : 3.761315 seconds
+Result [swordfish-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3203) : 3.7421 seconds
+Result [herring-0] : level-3 : parent(3593, 781, 3281) : (3515, 859, 3203) : 3.946933 seconds
+Result [blowfish-0] : level-3 : parent(3593, 781, 3281) : (3515, 703, 3203) : 3.711668 seconds
+Result [tarpon-0] : level-3 : parent(3593, 781, 3281) : (3671, 703, 3203) : 3.766134 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3515, 703, 3203) 3.7410574 seconds
+...done.
+
+OPTIMAL : (3515, 703, 3203) 3.7410574 seconds : 11.137671040991423 GFlops/sec
+
+Creating tasks for parent (3281, 781, 3281) ...
+Result [bonito-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3203) : 3.716619 seconds
+Result [mackerel-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3203) : 3.809021 seconds
+Result [char-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3359) : 3.734975 seconds
+Result [eel-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3359) : 3.735155 seconds
+Result [marlin-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3203) : 3.79497 seconds
+Result [perch-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3359) : 5.734173 seconds
+Result [blowfish-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3203) : 3.721108 seconds
+Result [barracuda-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3203) : 3.729142 seconds
+Result [tarpon-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3203) : 3.754475 seconds
+Result [shark-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3359) : 3.89391 seconds
+Result [bonito-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3203) : 3.703132 seconds
+Result [mackerel-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3359) : 3.736969 seconds
+Result [flounder-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3359) : 3.75743 seconds
+Result [swordfish-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3203) : 3.752541 seconds
+Result [sardine-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3359) : 3.802653 seconds
+Result [brill-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3203) : 3.921085 seconds
+Result [char-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3359) : 3.733695 seconds
+Result [eel-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3359) : 3.773702 seconds
+Result [marlin-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3359) : 3.759844 seconds
+Result [wahoo-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3203) : 3.75003 seconds
+Result [sole-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3359) : 3.968841 seconds
+Result [blowfish-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3203) : 3.720666 seconds
+Result [barracuda-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3203) : 3.713402 seconds
+Result [bonito-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3203) : 3.762017 seconds
+Result [mackerel-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3359) : 3.751143 seconds
+Result [dorado-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3359) : 3.763537 seconds
+Result [perch-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3359) : 5.620756 seconds
+Result [pollock-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3359) : 3.797285 seconds
+Result [anchovy-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3203) : 3.789237 seconds
+Result [flounder-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3359) : 3.738468 seconds
+Result [sardine-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3359) : 3.737047 seconds
+Result [brill-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3359) : 3.738692 seconds
+Result [shark-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3203) : 4.178394 seconds
+Result [halibut-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3203) : 3.720039 seconds
+Result [herring-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3203) : 4.017871 seconds
+Result [tarpon-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3203) : 3.766004 seconds
+Result [cod-0] : level-3 : parent(3281, 781, 3281) : (3203, 703, 3359) : 3.75731 seconds
+Result [grouper-0] : level-3 : parent(3281, 781, 3281) : (3203, 859, 3203) : 4.103455 seconds
+Result [swordfish-0] : level-3 : parent(3281, 781, 3281) : (3359, 859, 3359) : 3.908198 seconds
+Result [turbot-0] : level-3 : parent(3281, 781, 3281) : (3359, 703, 3203) : 3.877898 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3203, 703, 3359) 3.7496814 seconds
+...done.
+
+OPTIMAL : (3203, 703, 3359) 3.7496814 seconds : 11.112055191320165 GFlops/sec
+
+Creating tasks for parent (3593, 781, 3593) ...
+Result [anchovy-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3515) : 3.829833 seconds
+Result [char-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3671) : 3.775007 seconds
+Result [bonito-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3515) : 3.870268 seconds
+Result [flounder-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3671) : 3.915472 seconds
+Result [halibut-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3515) : 3.760147 seconds
+Result [dorado-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3671) : 3.757089 seconds
+Result [cod-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3671) : 3.794403 seconds
+Result [sole-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3671) : 4.004445 seconds
+Result [grouper-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3515) : 4.056465 seconds
+Result [brill-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3515) : 3.750693 seconds
+Result [turbot-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3515) : 3.747728 seconds
+Result [char-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3671) : 3.736027 seconds
+Result [anchovy-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3515) : 3.812705 seconds
+Result [bonito-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3671) : 3.750398 seconds
+Result [flounder-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3671) : 3.910476 seconds
+Result [barracuda-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3515) : 3.762603 seconds
+Result [cod-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3515) : 3.771898 seconds
+Result [halibut-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3671) : 3.909596 seconds
+Result [shark-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3671) : 4.24529 seconds
+Result [sole-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3515) : 3.967299 seconds
+Result [grouper-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3515) : 4.199302 seconds
+Result [eel-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3671) : 3.749305 seconds
+Result [marlin-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3515) : 3.800323 seconds
+Result [turbot-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3515) : 3.783971 seconds
+Result [dorado-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3671) : 3.92948 seconds
+Result [brill-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3515) : 3.921617 seconds
+Result [char-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3671) : 3.819977 seconds
+Result [anchovy-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3671) : 3.800368 seconds
+Result [bonito-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3671) : 3.806506 seconds
+Result [flounder-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3671) : 3.800402 seconds
+Result [perch-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3671) : 5.681834 seconds
+Result [sardine-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3671) : 3.825979 seconds
+Result [herring-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3515) : 3.975182 seconds
+Result [barracuda-0] : level-3 : parent(3593, 781, 3593) : (3671, 859, 3671) : 3.758451 seconds
+Result [tarpon-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3515) : 3.789349 seconds
+Result [wahoo-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3515) : 3.735506 seconds
+Result [blowfish-0] : level-3 : parent(3593, 781, 3593) : (3515, 703, 3515) : 3.748213 seconds
+Warning: No xauth data; using fake authentication data for X11 forwarding.
+Result [mackerel-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3515) : 3.783817 seconds
+Result [pollock-0] : level-3 : parent(3593, 781, 3593) : (3515, 859, 3671) : 3.788528 seconds
+Result [swordfish-0] : level-3 : parent(3593, 781, 3593) : (3671, 703, 3515) : 3.736681 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (3671, 703, 3515) 3.7643938 seconds
+...done.
+
+OPTIMAL : (3671, 703, 3515) 3.7643938 seconds : 11.068625887829977 GFlops/sec

--- a/results/experiment-1.log
+++ b/results/experiment-1.log
@@ -1,0 +1,2270 @@
+args : {'N': 8000, 'path_prefix': './workspace/parric-ttmm/ttmm/ikj/out', 'keep': [3, 3, 3, 1], 'partitions': [4, 2, 2, 2], 'parent_center': None, 'parent_size': None, 'iterations': 4}
+
+Creating Machine('anchovy')...done.
+Creating Machine('barracuda')...done.
+Creating Machine('blowfish')...done.
+Creating Machine('bonito')...done.
+Creating Machine('brill')...done.
+Creating Machine('char')...done.
+Creating Machine('cod')...done.
+Creating Machine('dorado')...done.
+Creating Machine('eel')...done.
+Creating Machine('flounder')...done.
+Creating Machine('grouper')...done.
+Creating Machine('halibut')...done.
+Creating Machine('herring')...done.
+Creating Machine('mackerel')...done.
+Creating Machine('marlin')...done.
+Creating Machine('perch')...done.
+Creating Machine('pollock')...done.
+Creating Machine('sardine')...done.
+Creating Machine('shark')...done.
+Creating Machine('sole')...done.
+Creating Machine('swordfish')...done.
+Creating Machine('tarpon')...done.
+Creating Machine('turbot')...done.
+Creating Machine('wahoo')...done.
+
+Creating tasks for parent (4000, 4000, 4000) ...
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 3000) : 15.554109 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 1000) : 16.247609 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 5000) : 16.635595 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 3000) : 15.680395 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 5000) : 17.923739 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 1000) : 16.175795 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 5000) : 16.731071 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 5000) : 16.690658 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 1000) : 16.223122 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 1000) : 16.580079 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 5000) : 16.729769 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 3000) : 15.454629 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 7000) : 18.183035 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 3000) : 15.368084 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 7000) : 17.800221 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 7000) : 19.593989 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 1000) : 19.680791 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 7000) : 17.745557 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 1000) : 16.213776 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 1000) : 20.072596 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 1000) : 19.739137 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 1000) : 20.127698 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 3000) : 16.19591 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 1000) : 19.823533 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (1000, 1000, 7000) : 28.923867 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 3000) : 23.4757 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 3000) : 23.167205 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 3000) : 23.264744 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 3000) : 23.249683 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 5000) : 23.783108 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 5000) : 23.214157 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 5000) : 22.985508 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 5000) : 23.361575 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 5000) : 23.272595 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 3000) : 28.313398 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 7000) : 23.730853 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 7000) : 24.256127 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 7000) : 23.661778 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 7000) : 23.761744 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 1000) : 22.974066 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 1000) : 22.953213 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (1000, 3000, 7000) : 25.5967 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 1000) : 23.347357 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 1000) : 23.006183 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 1000) : 22.694048 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 3000) : 25.170303 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 3000) : 25.090654 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 3000) : 24.918718 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 5000) : 25.60585 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 5000) : 25.562266 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 3000) : 24.865393 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 5000) : 25.54281 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 5000) : 26.517095 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 7000) : 23.777489 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 5000) : 25.435989 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 7000) : 24.262937 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 7000) : 24.343772 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 7000) : 23.832702 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 7000) : 27.756697 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 1000) : 27.456876 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 1000) : 26.933543 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 1000) : 27.153758 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 1000) : 26.816326 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (1000, 5000, 3000) : 39.575728 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 1000) : 26.953728 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 3000) : 26.527607 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 3000) : 26.54085 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 3000) : 28.575477 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 3000) : 26.02471 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 1000) : 16.208542 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 5000) : 26.096914 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 3000) : 26.422742 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 1000) : 16.224605 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 5000) : 26.008328 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 1000) : 16.786986 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 5000) : 25.973444 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 3000) : 15.380291 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 5000) : 26.001825 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 1000) : 16.279673 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 5000) : 26.078874 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 3000) : 15.360722 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 1000) : 17.767712 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 7000) : 27.367294 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 3000) : 15.555421 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 3000) : 15.620172 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 7000) : 27.155558 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 7000) : 26.848339 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 7000) : 27.732729 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (1000, 7000, 7000) : 27.378905 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 5000) : 16.808461 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 5000) : 18.648345 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 5000) : 16.504773 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 5000) : 16.741563 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 5000) : 16.645582 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 3000) : 26.627132 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 7000) : 17.881802 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 7000) : 17.85207 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 7000) : 18.275732 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 7000) : 17.960721 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (3000, 1000, 7000) : 18.881654 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 1000) : 19.942278 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 1000) : 19.812739 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 1000) : 19.892822 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 1000) : 19.812646 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 1000) : 19.827233 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 3000) : 23.584632 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 3000) : 23.205879 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 3000) : 23.201408 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 3000) : 23.42143 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 3000) : 23.301211 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 5000) : 23.441739 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 5000) : 23.66791 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 5000) : 23.284689 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 5000) : 23.357568 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 7000) : 23.378264 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 5000) : 24.993002 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 7000) : 23.628614 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 7000) : 23.96721 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 1000) : 22.972835 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 7000) : 23.792925 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 1000) : 22.844664 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 1000) : 22.800671 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 1000) : 23.125338 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 3000) : 24.997731 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 3000) : 25.036903 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 3000) : 25.030018 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 1000) : 28.67889 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 3000) : 25.138849 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (3000, 3000, 7000) : 36.61905 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 3000) : 25.633201 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 5000) : 25.532853 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 5000) : 25.929927 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 7000) : 24.421607 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 7000) : 24.045516 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 5000) : 25.833509 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 5000) : 25.496875 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 5000) : 25.965572 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 7000) : 23.891456 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 7000) : 23.503816 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (3000, 5000, 7000) : 26.479709 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 1000) : 26.632888 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 1000) : 26.824133 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 1000) : 27.042992 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 1000) : 26.514111 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 1000) : 27.112543 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 3000) : 26.305583 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 1000) : 16.242616 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 3000) : 26.539703 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 1000) : 16.233784 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 3000) : 26.393898 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 3000) : 26.329281 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 1000) : 16.176982 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 5000) : 26.184681 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 3000) : 26.340138 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 5000) : 28.284865 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 1000) : 17.228998 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 5000) : 26.563376 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 5000) : 26.52508 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 3000) : 15.715733 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 1000) : 16.253405 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 3000) : 15.318578 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 7000) : 27.162654 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 3000) : 15.641999 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 7000) : 27.148987 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 7000) : 26.945387 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 7000) : 27.159491 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 3000) : 15.759549 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 7000) : 27.917348 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 3000) : 15.634704 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 5000) : 16.496887 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 5000) : 16.625693 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (3000, 7000, 5000) : 39.491952 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 5000) : 16.20454 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 5000) : 16.561453 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 5000) : 16.429264 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 7000) : 17.870451 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 7000) : 17.74477 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 7000) : 17.70494 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 7000) : 19.150892 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (5000, 1000, 7000) : 19.945341 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 1000) : 19.849356 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 1000) : 20.296404 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 1000) : 20.062001 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 1000) : 19.895358 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 1000) : 19.708312 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 3000) : 23.317292 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 3000) : 23.264282 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 3000) : 23.38228 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 5000) : 23.268916 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 3000) : 23.468866 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 5000) : 24.079856 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 5000) : 23.041271 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 3000) : 23.549875 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 5000) : 23.178273 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 5000) : 23.199377 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 7000) : 23.740382 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 7000) : 23.602105 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 7000) : 23.908322 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 7000) : 23.339427 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 1000) : 23.005533 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 1000) : 22.912503 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 1000) : 22.970532 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 1000) : 28.35995 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 1000) : 25.530804 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 3000) : 25.431647 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 3000) : 25.066918 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 3000) : 25.278869 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 3000) : 25.121851 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (5000, 3000, 7000) : 36.653144 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 3000) : 24.859377 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 5000) : 25.701214 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 5000) : 25.636476 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 5000) : 25.77625 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 5000) : 25.883624 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 7000) : 23.924264 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 5000) : 26.37044 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 7000) : 23.709502 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 7000) : 23.822662 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 7000) : 23.778051 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (5000, 5000, 7000) : 23.710407 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 1000) : 26.741753 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 1000) : 26.764385 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 1000) : 26.415697 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 1000) : 26.88976 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 1000) : 26.861625 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 3000) : 26.225868 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 1000) : 16.19823 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 1000) : 16.286372 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 5000) : 26.427472 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 3000) : 27.345505 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 1000) : 16.256998 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 3000) : 28.517727 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 3000) : 29.383916 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 5000) : 26.228362 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 1000) : 16.297908 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 3000) : 26.519184 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 5000) : 26.042403 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 3000) : 15.548814 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 1000) : 16.211801 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 3000) : 15.563937 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 5000) : 26.211052 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 7000) : 27.149028 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 7000) : 27.023915 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 7000) : 27.638005 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 3000) : 15.369475 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 3000) : 15.374208 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 7000) : 26.903491 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 7000) : 27.907957 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (5000, 7000, 5000) : 38.855622 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 3000) : 15.609078 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 5000) : 16.694214 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 5000) : 16.621415 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 5000) : 16.543473 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 5000) : 16.887358 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 5000) : 16.092174 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 7000) : 17.806127 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 7000) : 18.185225 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 7000) : 19.737723 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 7000) : 20.106672 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (7000, 1000, 7000) : 17.85705 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 1000) : 19.794992 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 1000) : 20.118333 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 1000) : 19.630416 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 1000) : 19.942997 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 1000) : 19.872103 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 3000) : 23.354491 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 3000) : 23.477725 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 3000) : 23.32949 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 3000) : 23.509757 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 3000) : 23.305114 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 5000) : 23.058002 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 5000) : 23.663458 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 5000) : 23.170372 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 5000) : 23.354544 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 7000) : 23.590786 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 7000) : 23.773238 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 7000) : 24.217346 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 7000) : 23.81884 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 1000) : 23.038614 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 7000) : 23.709691 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 1000) : 23.164623 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 1000) : 25.86949 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 1000) : 26.200024 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 1000) : 22.954277 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (7000, 3000, 5000) : 36.501945 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 3000) : 24.699098 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 3000) : 25.124085 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 3000) : 25.10954 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 3000) : 25.001758 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 3000) : 25.241923 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 5000) : 25.661152 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 5000) : 25.764835 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 5000) : 25.678304 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 7000) : 24.339554 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 5000) : 25.677475 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 5000) : 25.665697 seconds
+Result [bonito-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 7000) : 23.983347 seconds
+Result [halibut-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 7000) : 23.708925 seconds
+Result [eel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 7000) : 24.004394 seconds
+Result [swordfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 5000, 7000) : 23.889516 seconds
+Result [shark-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 1000) : 27.523019 seconds
+Result [brill-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 1000) : 27.10467 seconds
+Result [marlin-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 1000) : 26.848893 seconds
+Result [pollock-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 1000) : 26.99819 seconds
+Result [dorado-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 1000) : 27.064452 seconds
+Result [mackerel-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 3000) : 26.162383 seconds
+Result [sole-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 3000) : 28.124278 seconds
+Result [herring-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 3000) : 29.42414 seconds
+Result [flounder-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 3000) : 26.057906 seconds
+Result [cod-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 5000) : 26.125988 seconds
+Result [barracuda-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 5000) : 26.171263 seconds
+Result [sardine-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 5000) : 26.309322 seconds
+Result [turbot-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 5000) : 26.090124 seconds
+Result [blowfish-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 5000) : 26.242542 seconds
+Result [char-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 7000) : 27.216404 seconds
+Result [wahoo-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 7000) : 27.112107 seconds
+Result [tarpon-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 7000) : 26.906428 seconds
+Result [grouper-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 7000) : 27.940981 seconds
+Result [anchovy-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 7000) : 27.27523 seconds
+Result [perch-0] : level-0 : parent(4000, 4000, 4000) : (7000, 7000, 3000) : 40.329201 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (7000, 1000, 3000) 15.4931024 seconds
+Selected : (5000, 1000, 3000) 15.6141126 seconds
+Selected : (1000, 1000, 3000) 15.650625400000001 seconds
+...done.
+
+Creating tasks for parent (7000, 1000, 3000) ...
+Result [eel-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 3500) : 14.946426 seconds
+Result [barracuda-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 2500) : 15.221605 seconds
+Result [pollock-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 3500) : 18.64181 seconds
+Result [cod-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 3500) : 14.928485 seconds
+Result [grouper-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 2500) : 19.117864 seconds
+Result [shark-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 3500) : 19.182215 seconds
+Result [brill-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 2500) : 15.235405 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [tarpon-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 2500) : 15.890529 seconds
+Result [halibut-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 2500) : 18.582555 seconds
+Result [anchovy-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 2500) : 15.215113 seconds
+Result [blowfish-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 2500) : 15.265411 seconds
+Result [swordfish-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 2500) : 15.224105 seconds
+Result [marlin-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 2500) : 18.798254 seconds
+Result [herring-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 2500) : 20.861798 seconds
+Result [wahoo-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 2500) : 15.243453 seconds
+Result [bonito-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 2500) : 15.178643 seconds
+Result [dorado-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 3500) : 14.935684 seconds
+Result [sole-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 3500) : 20.779709 seconds
+Result [eel-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 2500) : 15.243375 seconds
+Result [barracuda-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 3500) : 15.626639 seconds
+Result [turbot-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 2500) : 15.177567 seconds
+Result [perch-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 3500) : 31.521147 seconds
+Result [pollock-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 3500) : 14.96821 seconds
+Result [cod-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 3500) : 14.915035 seconds
+Result [mackerel-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 2500) : 18.787682 seconds
+Result [flounder-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 3500) : 14.917854 seconds
+Result [char-0] : level-1 : parent(7000, 1000, 3000) : (6500, 500, 3500) : 14.930509 seconds
+Result [shark-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 3500) : 15.668629 seconds
+Result [grouper-0] : level-1 : parent(7000, 1000, 3000) : (7500, 500, 3500) : 15.652293 seconds
+Result [brill-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 2500) : 18.463176 seconds
+Result [tarpon-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 2500) : 18.64811 seconds
+Result [halibut-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 2500) : 18.693749 seconds
+Result [blowfish-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 2500) : 18.656218 seconds
+Result [sardine-0] : level-1 : parent(7000, 1000, 3000) : (6500, 1500, 3500) : 18.871003 seconds
+Result [marlin-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 3500) : 18.962105 seconds
+Result [anchovy-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 2500) : 18.706634 seconds
+Result [wahoo-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 3500) : 18.810632 seconds
+Result [swordfish-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 3500) : 18.83859 seconds
+Result [herring-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 3500) : 21.507993 seconds
+Result [bonito-0] : level-1 : parent(7000, 1000, 3000) : (7500, 1500, 3500) : 18.831034 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (6500, 500, 3500) 14.9317916 seconds
+Selected : (6500, 500, 2500) 15.2232354 seconds
+Selected : (7500, 500, 2500) 15.3558058 seconds
+...done.
+
+Creating tasks for parent (6500, 500, 3500) ...
+Result [char-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3750) : 15.039703 seconds
+Result [flounder-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3750) : 15.038863 seconds
+Result [marlin-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3250) : 15.134497 seconds
+Result [turbot-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3250) : 14.792749 seconds
+Result [dorado-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3750) : 15.044942 seconds
+Result [halibut-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3250) : 15.09604 seconds
+Result [herring-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3250) : 17.352637 seconds
+Result [eel-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3750) : 15.05612 seconds
+Result [cod-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3750) : 15.069055 seconds
+Result [grouper-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3250) : 15.779526 seconds
+Result [barracuda-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3250) : 14.755367 seconds
+Result [mackerel-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3250) : 15.235828 seconds
+Result [shark-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3750) : 15.988378 seconds
+Result [blowfish-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3250) : 14.824778 seconds
+Result [sardine-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3750) : 15.73891 seconds
+Result [sole-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3750) : 18.085981 seconds
+Result [pollock-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3750) : 15.754068 seconds
+Result [wahoo-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3250) : 14.799857 seconds
+Result [tarpon-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3250) : 14.82855 seconds
+Result [perch-0] : level-2 : parent(6500, 500, 3500) : (6250, 750, 3750) : 26.57701 seconds
+Result [bonito-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3250) : 14.798472 seconds
+Result [flounder-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3750) : 15.00111 seconds
+Result [marlin-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3750) : 15.010133 seconds
+Result [swordfish-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3250) : 14.782838 seconds
+Result [dorado-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3750) : 15.01255 seconds
+Result [halibut-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3750) : 14.997966 seconds
+Result [brill-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3250) : 14.760196 seconds
+Result [turbot-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3750) : 15.703731 seconds
+Result [char-0] : level-2 : parent(6500, 500, 3500) : (6750, 250, 3250) : 14.750562 seconds
+Result [cod-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3250) : 15.148309 seconds
+Result [herring-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3250) : 17.381444 seconds
+Result [anchovy-0] : level-2 : parent(6500, 500, 3500) : (6250, 250, 3250) : 15.436562 seconds
+Result [grouper-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3250) : 15.574145 seconds
+Result [barracuda-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3250) : 15.121032 seconds
+Result [eel-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3250) : 15.126054 seconds
+Result [mackerel-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3750) : 16.423566 seconds
+Result [shark-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3750) : 16.106523 seconds
+Result [blowfish-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3750) : 15.866677 seconds
+Result [sardine-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3750) : 15.716066 seconds
+Result [sole-0] : level-2 : parent(6500, 500, 3500) : (6750, 750, 3750) : 18.311911 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (6750, 250, 3250) 14.7909112 seconds
+Selected : (6250, 250, 3250) 14.915075 seconds
+Selected : (6250, 250, 3750) 15.0497366 seconds
+...done.
+
+Creating tasks for parent (6750, 250, 3250) ...
+Result [barracuda-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3125) : 14.852913 seconds
+Result [brill-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3125) : 14.908066 seconds
+Result [grouper-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3125) : 15.219435 seconds
+Result [sole-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3375) : 16.061619 seconds
+Result [blowfish-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3125) : 14.84422 seconds
+Result [bonito-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3125) : 14.843285 seconds
+Result [eel-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3375) : 14.950388 seconds
+Result [mackerel-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3125) : 14.785631 seconds
+Result [marlin-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3125) : 14.729362 seconds
+Result [sardine-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3375) : 14.858404 seconds
+Result [dorado-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3375) : 14.932272 seconds
+Result [pollock-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3375) : 14.849598 seconds
+Result [halibut-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3125) : 15.40733 seconds
+Result [perch-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3375) : 21.955327 seconds
+Result [shark-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3375) : 16.593533 seconds
+Result [wahoo-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3125) : 14.818092 seconds
+Result [cod-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3375) : 14.959884 seconds
+Result [swordfish-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3125) : 14.8734 seconds
+Result [herring-0] : level-3 : parent(6750, 250, 3250) : (6625, 375, 3125) : 15.040761 seconds
+Result [flounder-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3375) : 14.904791 seconds
+Result [anchovy-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3125) : 14.864981 seconds
+Result [barracuda-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3125) : 14.84766 seconds
+Result [turbot-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3125) : 14.878656 seconds
+Result [grouper-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3375) : 15.318263 seconds
+Result [brill-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3375) : 15.6059 seconds
+Result [blowfish-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3375) : 14.949003 seconds
+Result [eel-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3125) : 15.16014 seconds
+Result [sole-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3375) : 16.082868 seconds
+Result [tarpon-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3125) : 14.837097 seconds
+Result [mackerel-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3125) : 14.716039 seconds
+Result [sardine-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3125) : 14.720762 seconds
+Result [bonito-0] : level-3 : parent(6750, 250, 3250) : (6875, 125, 3375) : 14.946199 seconds
+Result [char-0] : level-3 : parent(6750, 250, 3250) : (6625, 125, 3375) : 14.933322 seconds
+Result [marlin-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3125) : 14.725435 seconds
+Result [dorado-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3125) : 14.704992 seconds
+Result [halibut-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3375) : 14.82328 seconds
+Result [pollock-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3375) : 14.843607 seconds
+Result [wahoo-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3375) : 14.918466 seconds
+Result [shark-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3375) : 15.686338 seconds
+Result [perch-0] : level-3 : parent(6750, 250, 3250) : (6875, 375, 3375) : 22.13229 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6875, 375, 3125) 14.805473600000001 seconds
+...done.
+
+OPTIMAL : (6875, 375, 3125) 14.805473600000001 seconds : 11.527268311543013 GFlops/sec
+
+Creating tasks for parent (6250, 250, 3250) ...
+Result [brill-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3125) : 14.879681 seconds
+Result [swordfish-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3125) : 15.493236 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3125) : 15.52116 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3125) : 15.802665 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3125) : 14.83358 seconds
+Result [dorado-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3375) : 14.936232 seconds
+Result [halibut-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3125) : 14.723635 seconds
+Result [cod-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3375) : 14.927972 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3125) : 15.511016 seconds
+Result [flounder-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3375) : 15.580058 seconds
+Result [eel-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3375) : 14.924627 seconds
+Result [char-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3375) : 14.931184 seconds
+Result [sardine-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3375) : 14.966307 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3125) : 15.504076 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3125) : 14.724226 seconds
+Result [shark-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3375) : 15.267025 seconds
+Result [perch-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3375) : 22.124582 seconds
+Result [tarpon-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3125) : 14.934547 seconds
+Result [mackerel-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3125) : 15.413689 seconds
+Result [herring-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3125) : 15.431625 seconds
+Result [anchovy-0] : level-3 : parent(6250, 250, 3250) : (6125, 125, 3125) : 15.481172 seconds
+Result [turbot-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3125) : 14.794882 seconds
+Result [sole-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3375) : 16.123056 seconds
+Result [brill-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3125) : 14.863342 seconds
+Result [pollock-0] : level-3 : parent(6250, 250, 3250) : (6125, 375, 3375) : 14.871557 seconds
+Result [swordfish-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3375) : 15.597829 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3375) : 15.63421 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3375) : 14.930982 seconds
+Result [dorado-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3375) : 14.942963 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 3250) : (6375, 125, 3375) : 14.913154 seconds
+Result [halibut-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3125) : 14.689974 seconds
+Result [cod-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3125) : 14.696086 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3125) : 14.714784 seconds
+Result [flounder-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3125) : 14.728637 seconds
+Result [eel-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3125) : 14.697436 seconds
+Result [sardine-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3375) : 14.838214 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3375) : 14.862939 seconds
+Result [char-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3375) : 14.840048 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3375) : 15.521584 seconds
+Result [shark-0] : level-3 : parent(6250, 250, 3250) : (6375, 375, 3375) : 15.266418 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6375, 375, 3125) 14.7053834 seconds
+...done.
+
+OPTIMAL : (6375, 375, 3125) 14.7053834 seconds : 11.605727101727021 GFlops/sec
+
+Creating tasks for parent (6250, 250, 3750) ...
+Result [brill-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3625) : 15.08682 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3625) : 15.179854 seconds
+Result [turbot-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3625) : 15.135932 seconds
+Result [char-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3875) : 14.90129 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3625) : 15.107301 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3625) : 15.058895 seconds
+Result [anchovy-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3625) : 15.725425 seconds
+Result [eel-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3875) : 14.888056 seconds
+Result [sole-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3875) : 16.144799 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3625) : 16.853239 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3625) : 14.960112 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3625) : 15.047915 seconds
+Result [herring-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3625) : 15.168702 seconds
+Result [dorado-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3875) : 15.553448 seconds
+Result [cod-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3875) : 14.874079 seconds
+Result [swordfish-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3625) : 15.099915 seconds
+Result [shark-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3875) : 16.326065 seconds
+Result [mackerel-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3625) : 14.980283 seconds
+Result [sardine-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3875) : 15.130507 seconds
+Result [flounder-0] : level-3 : parent(6250, 250, 3750) : (6125, 125, 3875) : 14.900888 seconds
+Result [halibut-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3625) : 14.989586 seconds
+Result [tarpon-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3625) : 15.128737 seconds
+Result [pollock-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3875) : 15.131061 seconds
+Result [turbot-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3875) : 14.901253 seconds
+Result [brill-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3625) : 15.727095 seconds
+Result [char-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3875) : 14.935394 seconds
+Result [perch-0] : level-3 : parent(6250, 250, 3750) : (6125, 375, 3875) : 22.658223 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3875) : 15.591526 seconds
+Result [anchovy-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3625) : 15.087216 seconds
+Result [eel-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3625) : 14.972972 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3875) : 14.875711 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3625) : 14.969371 seconds
+Result [sole-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3625) : 15.93585 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3875) : 15.095421 seconds
+Result [dorado-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3875) : 15.151481 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3625) : 15.965388 seconds
+Result [herring-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3875) : 16.67925 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 3750) : (6375, 125, 3875) : 14.881449 seconds
+Result [cod-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3875) : 15.095562 seconds
+Result [swordfish-0] : level-3 : parent(6250, 250, 3750) : (6375, 375, 3875) : 15.114055 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6125, 125, 3875) 15.0235522 seconds
+...done.
+
+OPTIMAL : (6125, 125, 3875) 15.0235522 seconds : 11.359941004276383 GFlops/sec
+
+Creating tasks for parent (6500, 500, 2500) ...
+Result [dorado-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2750) : 14.617939 seconds
+Result [anchovy-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2250) : 14.98931 seconds
+Result [swordfish-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2250) : 14.999913 seconds
+Result [flounder-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2750) : 14.598088 seconds
+Result [cod-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2750) : 14.59688 seconds
+Result [barracuda-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2250) : 15.049991 seconds
+Result [char-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2750) : 14.599806 seconds
+Result [sardine-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2750) : 14.763486 seconds
+Result [brill-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2250) : 14.995652 seconds
+Result [herring-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2250) : 16.011519 seconds
+Result [eel-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2750) : 14.600679 seconds
+Result [bonito-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2250) : 14.9896 seconds
+Result [halibut-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2250) : 15.137306 seconds
+Result [wahoo-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2250) : 14.978569 seconds
+Result [pollock-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2750) : 14.723141 seconds
+Result [marlin-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2250) : 15.125577 seconds
+Result [mackerel-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2250) : 15.143666 seconds
+Result [shark-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2750) : 15.310775 seconds
+Result [dorado-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2250) : 15.095103 seconds
+Result [swordfish-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2750) : 14.645945 seconds
+Result [anchovy-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2750) : 14.901419 seconds
+Result [tarpon-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2250) : 15.008081 seconds
+Result [barracuda-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2750) : 14.637184 seconds
+Result [flounder-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2750) : 15.268779 seconds
+Result [cod-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2750) : 15.268961 seconds
+Result [blowfish-0] : level-2 : parent(6500, 500, 2500) : (6250, 250, 2250) : 14.997152 seconds
+Result [grouper-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2250) : 15.488695 seconds
+Result [char-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2250) : 15.128975 seconds
+Result [sardine-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2250) : 15.087879 seconds
+Result [brill-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2250) : 15.134197 seconds
+Result [turbot-0] : level-2 : parent(6500, 500, 2500) : (6750, 250, 2250) : 15.647328 seconds
+Result [perch-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2750) : 24.057964 seconds
+Result [eel-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2250) : 15.135448 seconds
+Result [bonito-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2750) : 14.855186 seconds
+Result [halibut-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2750) : 14.857981 seconds
+Result [sole-0] : level-2 : parent(6500, 500, 2500) : (6250, 750, 2750) : 16.512736 seconds
+Result [herring-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2250) : 16.949003 seconds
+Result [wahoo-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2750) : 14.80205 seconds
+Result [pollock-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2750) : 14.69592 seconds
+Result [marlin-0] : level-2 : parent(6500, 500, 2500) : (6750, 750, 2750) : 14.914046 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (6250, 250, 2750) 14.6026784 seconds
+Selected : (6750, 750, 2750) 14.8250366 seconds
+Selected : (6750, 250, 2750) 14.9444576 seconds
+...done.
+
+Creating tasks for parent (6250, 250, 2750) ...
+Result [eel-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2875) : 14.735501 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2625) : 14.909731 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2625) : 15.716165 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2625) : 16.329877 seconds
+Result [flounder-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2875) : 14.721751 seconds
+Result [mackerel-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2625) : 15.048192 seconds
+Result [shark-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2875) : 15.554375 seconds
+Result [brill-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2625) : 14.927766 seconds
+Result [turbot-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2625) : 14.90535 seconds
+Result [pollock-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2875) : 14.669514 seconds
+Result [anchovy-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2625) : 14.89016 seconds
+Result [perch-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2875) : 21.791179 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2625) : 14.896255 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2625) : 15.585752 seconds
+Result [sardine-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2875) : 14.648529 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2625) : 14.899126 seconds
+Result [char-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2875) : 14.812316 seconds
+Result [tarpon-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2625) : 14.953082 seconds
+Result [swordfish-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2625) : 14.907693 seconds
+Result [herring-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2625) : 15.43107 seconds
+Result [barracuda-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2875) : 14.766332 seconds
+Result [eel-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2625) : 14.912097 seconds
+Result [dorado-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2875) : 14.822597 seconds
+Result [marlin-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2875) : 14.745772 seconds
+Result [grouper-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2875) : 15.418296 seconds
+Result [mackerel-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2875) : 14.776186 seconds
+Result [flounder-0] : level-3 : parent(6250, 250, 2750) : (6375, 125, 2875) : 15.384542 seconds
+Result [cod-0] : level-3 : parent(6250, 250, 2750) : (6125, 125, 2875) : 14.714113 seconds
+Result [sole-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2875) : 15.396461 seconds
+Result [shark-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2625) : 15.430235 seconds
+Result [turbot-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2625) : 14.990823 seconds
+Result [halibut-0] : level-3 : parent(6250, 250, 2750) : (6125, 375, 2625) : 15.013773 seconds
+Result [pollock-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2625) : 15.037549 seconds
+Result [anchovy-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2625) : 15.04689 seconds
+Result [bonito-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2875) : 14.661896 seconds
+Result [blowfish-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2875) : 14.68825 seconds
+Result [sardine-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2875) : 14.624688 seconds
+Result [brill-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2625) : 15.028725 seconds
+Result [wahoo-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2875) : 14.695174 seconds
+Result [perch-0] : level-3 : parent(6250, 250, 2750) : (6375, 375, 2875) : 21.783423 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6125, 125, 2875) 14.7612556 seconds
+...done.
+
+OPTIMAL : (6125, 125, 2875) 14.7612556 seconds : 11.561798758275458 GFlops/sec
+
+Creating tasks for parent (6750, 750, 2750) ...
+Result [wahoo-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2625) : 15.227435 seconds
+Result [anchovy-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2625) : 15.362229 seconds
+Result [cod-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2875) : 15.389883 seconds
+Result [eel-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2875) : 14.863485 seconds
+Result [sardine-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2875) : 15.099138 seconds
+Result [bonito-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2625) : 15.247722 seconds
+Result [tarpon-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2625) : 15.488226 seconds
+Result [halibut-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2625) : 15.792923 seconds
+Result [barracuda-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2625) : 15.232015 seconds
+Result [blowfish-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2625) : 15.305984 seconds
+Result [mackerel-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2625) : 15.860953 seconds
+Result [grouper-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2625) : 16.151172 seconds
+Result [dorado-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2875) : 14.710858 seconds
+Result [char-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2875) : 14.730579 seconds
+Result [flounder-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2875) : 15.365601 seconds
+Result [shark-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2875) : 15.411405 seconds
+Result [herring-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2625) : 17.683742 seconds
+Result [marlin-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2625) : 15.909116 seconds
+Result [sole-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2875) : 16.285422 seconds
+Result [pollock-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2875) : 14.972009 seconds
+Result [turbot-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2625) : 15.928028 seconds
+Result [swordfish-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2625) : 15.317315 seconds
+Result [brill-0] : level-3 : parent(6750, 750, 2750) : (6625, 625, 2625) : 15.290014 seconds
+Result [perch-0] : level-3 : parent(6750, 750, 2750) : (6625, 875, 2875) : 25.739944 seconds
+Result [cod-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2875) : 14.709994 seconds
+Result [wahoo-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2625) : 15.246348 seconds
+Result [eel-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2875) : 14.768328 seconds
+Result [sardine-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2875) : 14.76849 seconds
+Result [bonito-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2875) : 14.743129 seconds
+Result [anchovy-0] : level-3 : parent(6750, 750, 2750) : (6875, 625, 2875) : 14.71278 seconds
+Result [tarpon-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2625) : 15.804564 seconds
+Result [halibut-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2625) : 15.796975 seconds
+Result [blowfish-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2625) : 15.78789 seconds
+Result [grouper-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2875) : 15.487998 seconds
+Result [char-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2875) : 15.002006 seconds
+Result [mackerel-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2625) : 15.956314 seconds
+Result [dorado-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2875) : 15.379333 seconds
+Result [flounder-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2875) : 15.116896 seconds
+Result [barracuda-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2625) : 15.749206 seconds
+Result [shark-0] : level-3 : parent(6750, 750, 2750) : (6875, 875, 2875) : 15.327981 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6875, 625, 2875) 14.7405442 seconds
+...done.
+
+OPTIMAL : (6875, 625, 2875) 14.7405442 seconds : 11.578043819214399 GFlops/sec
+
+Creating tasks for parent (6750, 250, 2750) ...
+Result [dorado-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2875) : 14.811386 seconds
+Result [swordfish-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2625) : 14.938512 seconds
+Result [mackerel-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2625) : 15.125465 seconds
+Result [barracuda-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2625) : 15.600881 seconds
+Result [char-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2875) : 14.738715 seconds
+Result [marlin-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2625) : 15.069994 seconds
+Result [bonito-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2625) : 15.569006 seconds
+Result [flounder-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2875) : 14.742144 seconds
+Result [eel-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2875) : 14.750766 seconds
+Result [brill-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2625) : 14.904644 seconds
+Result [pollock-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2875) : 14.61386 seconds
+Result [cod-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2875) : 14.723867 seconds
+Result [anchovy-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2625) : 15.196638 seconds
+Result [tarpon-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2625) : 14.97373 seconds
+Result [shark-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2875) : 15.037721 seconds
+Result [grouper-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2625) : 15.693477 seconds
+Result [sardine-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2875) : 14.619788 seconds
+Result [blowfish-0] : level-3 : parent(6750, 250, 2750) : (6625, 125, 2625) : 15.040201 seconds
+Result [sole-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2875) : 15.621527 seconds
+Result [wahoo-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2625) : 14.955489 seconds
+Result [halibut-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2625) : 15.023646 seconds
+Result [dorado-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2625) : 14.900154 seconds
+Result [swordfish-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2875) : 14.762087 seconds
+Result [mackerel-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2875) : 14.811022 seconds
+Result [barracuda-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2875) : 14.818264 seconds
+Result [herring-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2625) : 15.85476 seconds
+Result [char-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2875) : 14.734425 seconds
+Result [marlin-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2875) : 14.775441 seconds
+Result [turbot-0] : level-3 : parent(6750, 250, 2750) : (6875, 125, 2625) : 14.913892 seconds
+Result [bonito-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2625) : 15.046609 seconds
+Result [perch-0] : level-3 : parent(6750, 250, 2750) : (6625, 375, 2875) : 21.520652 seconds
+Result [flounder-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2625) : 15.001112 seconds
+Result [brill-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2625) : 15.02556 seconds
+Result [cod-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2875) : 14.62493 seconds
+Result [eel-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2625) : 15.031724 seconds
+Result [anchovy-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2875) : 14.638745 seconds
+Result [pollock-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2625) : 15.07996 seconds
+Result [shark-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2875) : 15.327151 seconds
+Result [grouper-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2875) : 15.426962 seconds
+Result [tarpon-0] : level-3 : parent(6750, 250, 2750) : (6875, 375, 2875) : 14.685314 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (6625, 125, 2875) 14.7533756 seconds
+...done.
+
+OPTIMAL : (6625, 125, 2875) 14.7533756 seconds : 11.567974089039437 GFlops/sec
+
+Creating tasks for parent (7500, 500, 2500) ...
+Result [char-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2750) : 14.60739 seconds
+Result [pollock-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2750) : 14.739693 seconds
+Result [marlin-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2250) : 15.167292 seconds
+Result [turbot-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2250) : 15.151108 seconds
+Result [mackerel-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2250) : 15.197336 seconds
+Result [shark-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2750) : 15.507934 seconds
+Result [cod-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2750) : 14.579324 seconds
+Result [anchovy-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2250) : 15.037046 seconds
+Result [grouper-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2250) : 15.634231 seconds
+Result [dorado-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2750) : 14.607001 seconds
+Result [sardine-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2750) : 14.798062 seconds
+Result [wahoo-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2250) : 15.623896 seconds
+Result [eel-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2750) : 14.589827 seconds
+Result [tarpon-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2250) : 14.992622 seconds
+Result [barracuda-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2250) : 14.956639 seconds
+Result [brill-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2250) : 15.005218 seconds
+Result [halibut-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2250) : 15.133065 seconds
+Result [blowfish-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2250) : 15.019615 seconds
+Result [sole-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2750) : 15.904277 seconds
+Result [pollock-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2750) : 14.658694 seconds
+Result [char-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2250) : 14.96211 seconds
+Result [marlin-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2750) : 14.680413 seconds
+Result [bonito-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2250) : 14.949512 seconds
+Result [perch-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2750) : 24.571989 seconds
+Result [flounder-0] : level-2 : parent(7500, 500, 2500) : (7250, 250, 2750) : 14.583675 seconds
+Result [turbot-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2750) : 15.275975 seconds
+Result [shark-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2750) : 15.909702 seconds
+Result [cod-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2250) : 15.074848 seconds
+Result [mackerel-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2750) : 14.605931 seconds
+Result [swordfish-0] : level-2 : parent(7500, 500, 2500) : (7750, 250, 2250) : 15.021103 seconds
+Result [anchovy-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2250) : 15.413872 seconds
+Result [grouper-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2250) : 15.768381 seconds
+Result [dorado-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2250) : 15.103451 seconds
+Result [sardine-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2250) : 15.084188 seconds
+Result [herring-0] : level-2 : parent(7500, 500, 2500) : (7250, 750, 2250) : 16.976849 seconds
+Result [wahoo-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2750) : 14.806312 seconds
+Result [eel-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2750) : 14.85343 seconds
+Result [tarpon-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2750) : 14.820164 seconds
+Result [barracuda-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2750) : 14.737874 seconds
+Result [brill-0] : level-2 : parent(7500, 500, 2500) : (7750, 750, 2750) : 14.805465 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (7250, 250, 2750) 14.5934434 seconds
+Selected : (7750, 750, 2750) 14.804649 seconds
+Selected : (7250, 250, 2250) 14.993606 seconds
+...done.
+
+Creating tasks for parent (7250, 250, 2750) ...
+Result [cod-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2875) : 14.732374 seconds
+Result [dorado-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2875) : 14.749893 seconds
+Result [flounder-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2875) : 15.046388 seconds
+Result [sardine-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2875) : 15.289304 seconds
+Result [shark-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2875) : 15.64506 seconds
+Result [barracuda-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2625) : 14.98644 seconds
+Result [brill-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2625) : 15.018673 seconds
+Result [halibut-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2625) : 15.012621 seconds
+Result [grouper-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2625) : 15.700653 seconds
+Result [anchovy-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2625) : 14.982741 seconds
+Result [bonito-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2625) : 14.904365 seconds
+Result [tarpon-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2625) : 15.128821 seconds
+Result [mackerel-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2625) : 15.043812 seconds
+Result [eel-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2875) : 15.411611 seconds
+Result [wahoo-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2625) : 14.908454 seconds
+Result [char-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2875) : 15.422052 seconds
+Result [perch-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2875) : 21.698219 seconds
+Result [marlin-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2625) : 15.070238 seconds
+Result [herring-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2625) : 15.209304 seconds
+Result [blowfish-0] : level-3 : parent(7250, 250, 2750) : (7125, 125, 2625) : 14.915686 seconds
+Result [pollock-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2875) : 14.681909 seconds
+Result [turbot-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2625) : 15.047649 seconds
+Result [dorado-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2875) : 14.727825 seconds
+Result [flounder-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2875) : 14.717328 seconds
+Result [sardine-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2875) : 14.729259 seconds
+Result [cod-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2625) : 15.57061 seconds
+Result [swordfish-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2625) : 14.978653 seconds
+Result [shark-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2875) : 15.419553 seconds
+Result [barracuda-0] : level-3 : parent(7250, 250, 2750) : (7375, 125, 2875) : 14.738904 seconds
+Result [halibut-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2625) : 15.030492 seconds
+Result [brill-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2625) : 15.140343 seconds
+Result [sole-0] : level-3 : parent(7250, 250, 2750) : (7125, 375, 2875) : 15.661777 seconds
+Result [bonito-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2625) : 15.006343 seconds
+Result [grouper-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2625) : 16.351898 seconds
+Result [tarpon-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2875) : 14.660477 seconds
+Result [anchovy-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2625) : 15.057872 seconds
+Result [mackerel-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2875) : 14.684443 seconds
+Result [eel-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2875) : 15.321706 seconds
+Result [char-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2875) : 14.668716 seconds
+Result [wahoo-0] : level-3 : parent(7250, 250, 2750) : (7375, 375, 2875) : 15.279982 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (7375, 125, 2875) 14.8665738 seconds
+...done.
+
+OPTIMAL : (7375, 125, 2875) 14.8665738 seconds : 11.479892338520303 GFlops/sec
+
+Creating tasks for parent (7750, 750, 2750) ...
+Result [char-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2875) : 14.764977 seconds
+Result [turbot-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2625) : 15.345545 seconds
+Result [sole-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2875) : 16.177064 seconds
+Result [eel-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2875) : 14.736137 seconds
+Result [anchovy-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2625) : 15.301744 seconds
+Result [flounder-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2875) : 15.373461 seconds
+Result [brill-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2625) : 15.927741 seconds
+Result [barracuda-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2625) : 15.940502 seconds
+Result [dorado-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2875) : 14.748083 seconds
+Result [wahoo-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2625) : 15.268249 seconds
+Result [halibut-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2625) : 15.834576 seconds
+Result [bonito-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2625) : 15.23416 seconds
+Result [mackerel-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2625) : 15.807255 seconds
+Result [grouper-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2625) : 15.948746 seconds
+Result [cod-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2875) : 14.71463 seconds
+Result [shark-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2875) : 15.350286 seconds
+Result [swordfish-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2625) : 15.364438 seconds
+Result [blowfish-0] : level-3 : parent(7750, 750, 2750) : (7625, 625, 2625) : 15.309772 seconds
+Result [pollock-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2875) : 15.098501 seconds
+Result [herring-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2625) : 16.852447 seconds
+Result [sardine-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2875) : 14.986395 seconds
+Result [marlin-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2625) : 15.839878 seconds
+Result [char-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2625) : 15.238253 seconds
+Result [turbot-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2875) : 14.697743 seconds
+Result [tarpon-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2625) : 15.35614 seconds
+Result [eel-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2875) : 14.742509 seconds
+Result [sole-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2875) : 15.607645 seconds
+Result [anchovy-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2875) : 14.747358 seconds
+Result [flounder-0] : level-3 : parent(7750, 750, 2750) : (7875, 625, 2875) : 14.771346 seconds
+Result [brill-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2625) : 15.820155 seconds
+Result [dorado-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2625) : 15.655778 seconds
+Result [wahoo-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2625) : 16.099523 seconds
+Result [halibut-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2625) : 15.676008 seconds
+Result [barracuda-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2625) : 15.675166 seconds
+Result [bonito-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2875) : 15.04169 seconds
+Result [mackerel-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2875) : 15.186819 seconds
+Result [grouper-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2875) : 15.743146 seconds
+Result [cod-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2875) : 15.051534 seconds
+Result [shark-0] : level-3 : parent(7750, 750, 2750) : (7875, 875, 2875) : 15.442781 seconds
+Result [perch-0] : level-3 : parent(7750, 750, 2750) : (7625, 875, 2875) : 25.682791 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (7625, 625, 2875) 14.8674576 seconds
+...done.
+
+OPTIMAL : (7625, 625, 2875) 14.8674576 seconds : 11.479209913244794 GFlops/sec
+
+Creating tasks for parent (7250, 250, 2250) ...
+Result [brill-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2125) : 15.001435 seconds
+Result [wahoo-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2125) : 14.98569 seconds
+Result [eel-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2375) : 15.23393 seconds
+Result [grouper-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2125) : 16.13557 seconds
+Result [sole-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2375) : 15.975059 seconds
+Result [sardine-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2375) : 15.056919 seconds
+Result [flounder-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2375) : 15.184203 seconds
+Result [herring-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2125) : 15.226786 seconds
+Result [halibut-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2125) : 15.584077 seconds
+Result [swordfish-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2125) : 14.99851 seconds
+Result [anchovy-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2125) : 15.051943 seconds
+Result [cod-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2375) : 15.14197 seconds
+Result [barracuda-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2125) : 15.005837 seconds
+Result [blowfish-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2125) : 15.673935 seconds
+Result [turbot-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2125) : 15.029262 seconds
+Result [marlin-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2125) : 14.953147 seconds
+Result [shark-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2375) : 16.228901 seconds
+Result [perch-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2375) : 22.340606 seconds
+Result [mackerel-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2125) : 14.908474 seconds
+Result [char-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2375) : 15.17294 seconds
+Result [bonito-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2125) : 15.645985 seconds
+Result [tarpon-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2125) : 15.041962 seconds
+Result [pollock-0] : level-3 : parent(7250, 250, 2250) : (7125, 375, 2375) : 15.116984 seconds
+Result [brill-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2125) : 14.981683 seconds
+Result [wahoo-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2375) : 15.17236 seconds
+Result [eel-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2375) : 15.241958 seconds
+Result [dorado-0] : level-3 : parent(7250, 250, 2250) : (7125, 125, 2375) : 15.178955 seconds
+Result [flounder-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2125) : 14.946944 seconds
+Result [sardine-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2375) : 15.153219 seconds
+Result [grouper-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2375) : 16.268625 seconds
+Result [halibut-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2125) : 14.905297 seconds
+Result [herring-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2125) : 15.335016 seconds
+Result [sole-0] : level-3 : parent(7250, 250, 2250) : (7375, 125, 2375) : 16.362426 seconds
+Result [swordfish-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2125) : 14.883684 seconds
+Result [anchovy-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2125) : 14.975086 seconds
+Result [cod-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2375) : 15.058704 seconds
+Result [barracuda-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2375) : 15.101719 seconds
+Result [blowfish-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2375) : 15.096204 seconds
+Result [turbot-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2375) : 15.163985 seconds
+Result [marlin-0] : level-3 : parent(7250, 250, 2250) : (7375, 375, 2375) : 15.061339 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (7375, 125, 2125) 15.0074214 seconds
+...done.
+
+OPTIMAL : (7375, 125, 2125) 15.0074214 seconds : 11.372151292204446 GFlops/sec
+
+Creating tasks for parent (5000, 1000, 3000) ...
+Result [eel-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 3500) : 15.008719 seconds
+Result [anchovy-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 2500) : 15.247167 seconds
+Result [dorado-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 3500) : 14.937786 seconds
+Result [flounder-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 3500) : 14.943897 seconds
+Result [swordfish-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 2500) : 15.230413 seconds
+Result [mackerel-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 2500) : 18.67159 seconds
+Result [pollock-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 3500) : 18.942077 seconds
+Result [blowfish-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 2500) : 15.264311 seconds
+Result [sardine-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 3500) : 18.790899 seconds
+Result [grouper-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 2500) : 18.941397 seconds
+Result [wahoo-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 2500) : 15.21358 seconds
+Result [cod-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 3500) : 15.606851 seconds
+Result [halibut-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 2500) : 18.608729 seconds
+Result [marlin-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 2500) : 18.825205 seconds
+Result [char-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 3500) : 14.947753 seconds
+Result [bonito-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 2500) : 15.210247 seconds
+Result [barracuda-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 2500) : 15.246159 seconds
+Result [tarpon-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 2500) : 15.220775 seconds
+Result [brill-0] : level-1 : parent(5000, 1000, 3000) : (4500, 500, 2500) : 15.324128 seconds
+Result [shark-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 3500) : 19.193402 seconds
+Result [turbot-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 2500) : 15.160755 seconds
+Result [anchovy-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 3500) : 15.055961 seconds
+Result [eel-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 2500) : 15.882402 seconds
+Result [dorado-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 3500) : 15.025874 seconds
+Result [flounder-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 3500) : 14.960881 seconds
+Result [swordfish-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 3500) : 14.950355 seconds
+Result [sole-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 3500) : 20.836054 seconds
+Result [herring-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 2500) : 20.03831 seconds
+Result [mackerel-0] : level-1 : parent(5000, 1000, 3000) : (5500, 500, 3500) : 14.967982 seconds
+Result [perch-0] : level-1 : parent(5000, 1000, 3000) : (4500, 1500, 3500) : 31.525027 seconds
+Result [pollock-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 2500) : 18.555189 seconds
+Result [blowfish-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 2500) : 18.675976 seconds
+Result [sardine-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 2500) : 18.578347 seconds
+Result [wahoo-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 2500) : 18.456979 seconds
+Result [grouper-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 2500) : 19.115061 seconds
+Result [cod-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 3500) : 18.864592 seconds
+Result [halibut-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 3500) : 18.769179 seconds
+Result [char-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 3500) : 18.810255 seconds
+Result [marlin-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 3500) : 18.944529 seconds
+Result [bonito-0] : level-1 : parent(5000, 1000, 3000) : (5500, 1500, 3500) : 18.796285 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (5500, 500, 3500) 14.9922106 seconds
+Selected : (4500, 500, 3500) 15.0890012 seconds
+Selected : (4500, 500, 2500) 15.2584024 seconds
+...done.
+
+Creating tasks for parent (5500, 500, 3500) ...
+Result [blowfish-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3250) : 14.792168 seconds
+Result [tarpon-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3250) : 14.778586 seconds
+Result [halibut-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3250) : 15.132935 seconds
+Result [grouper-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3250) : 15.81749 seconds
+Result [barracuda-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3250) : 14.744268 seconds
+Result [swordfish-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3250) : 14.800389 seconds
+Result [eel-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3750) : 15.046083 seconds
+Result [mackerel-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3250) : 15.819574 seconds
+Result [wahoo-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3250) : 14.768564 seconds
+Result [char-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3750) : 15.059073 seconds
+Result [cod-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3750) : 15.039116 seconds
+Result [bonito-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3250) : 14.7677 seconds
+Result [dorado-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3750) : 15.011034 seconds
+Result [flounder-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3750) : 15.011936 seconds
+Result [pollock-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3750) : 15.640003 seconds
+Result [sole-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3750) : 18.069293 seconds
+Result [shark-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3750) : 16.165629 seconds
+Result [perch-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3750) : 26.312944 seconds
+Result [marlin-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3250) : 15.195195 seconds
+Result [sardine-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3750) : 15.630814 seconds
+Result [blowfish-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3250) : 14.755498 seconds
+Result [anchovy-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3250) : 14.748604 seconds
+Result [halibut-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3750) : 15.018651 seconds
+Result [tarpon-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3750) : 15.68313 seconds
+Result [grouper-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3750) : 15.458557 seconds
+Result [swordfish-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3750) : 14.997785 seconds
+Result [brill-0] : level-2 : parent(5500, 500, 3500) : (5250, 250, 3250) : 14.780342 seconds
+Result [eel-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3250) : 15.168778 seconds
+Result [barracuda-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3750) : 15.711858 seconds
+Result [mackerel-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3250) : 15.184218 seconds
+Result [herring-0] : level-2 : parent(5500, 500, 3500) : (5250, 750, 3250) : 15.799099 seconds
+Result [wahoo-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3250) : 14.989383 seconds
+Result [cod-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3250) : 15.122298 seconds
+Result [char-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3250) : 15.125074 seconds
+Result [turbot-0] : level-2 : parent(5500, 500, 3500) : (5750, 250, 3250) : 14.745407 seconds
+Result [dorado-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3750) : 15.572009 seconds
+Result [bonito-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3750) : 15.973502 seconds
+Result [flounder-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3750) : 16.016639 seconds
+Result [pollock-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3750) : 15.832148 seconds
+Result [sole-0] : level-2 : parent(5500, 500, 3500) : (5750, 750, 3750) : 17.862968 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (5250, 250, 3250) 14.7666164 seconds
+Selected : (5750, 250, 3250) 14.769688799999999 seconds
+Selected : (5250, 250, 3750) 15.0334484 seconds
+...done.
+
+Creating tasks for parent (5250, 250, 3250) ...
+Result [char-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3375) : 14.915921 seconds
+Result [sardine-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3375) : 14.840265 seconds
+Result [flounder-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3375) : 14.948566 seconds
+Result [herring-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3125) : 15.56919 seconds
+Result [grouper-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3125) : 15.565412 seconds
+Result [halibut-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3125) : 14.700353 seconds
+Result [cod-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3375) : 14.894708 seconds
+Result [bonito-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3125) : 15.46269 seconds
+Result [blowfish-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3125) : 14.839701 seconds
+Result [dorado-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3375) : 14.928942 seconds
+Result [tarpon-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3125) : 14.817814 seconds
+Result [mackerel-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3125) : 14.895869 seconds
+Result [sole-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3375) : 16.081329 seconds
+Result [brill-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3125) : 14.810137 seconds
+Result [pollock-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3375) : 14.877641 seconds
+Result [shark-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3375) : 15.19835 seconds
+Result [barracuda-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3125) : 14.835869 seconds
+Result [anchovy-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3125) : 14.909032 seconds
+Result [marlin-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3125) : 14.716611 seconds
+Result [eel-0] : level-3 : parent(5250, 250, 3250) : (5125, 125, 3375) : 14.92143 seconds
+Result [char-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3125) : 14.817377 seconds
+Result [flounder-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3375) : 14.915976 seconds
+Result [swordfish-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3125) : 14.809068 seconds
+Result [herring-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3375) : 15.303211 seconds
+Result [grouper-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3375) : 15.276117 seconds
+Result [perch-0] : level-3 : parent(5250, 250, 3250) : (5125, 375, 3375) : 22.049511 seconds
+Result [halibut-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3375) : 14.922113 seconds
+Result [sardine-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3375) : 14.916989 seconds
+Result [cod-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3125) : 14.741225 seconds
+Result [bonito-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3125) : 14.778243 seconds
+Result [turbot-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3125) : 14.843185 seconds
+Result [wahoo-0] : level-3 : parent(5250, 250, 3250) : (5375, 125, 3125) : 14.841878 seconds
+Result [blowfish-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3125) : 14.722325 seconds
+Result [dorado-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3125) : 14.757607 seconds
+Result [mackerel-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3375) : 15.053238 seconds
+Result [tarpon-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3125) : 14.705705 seconds
+Result [sole-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3375) : 15.827432 seconds
+Result [brill-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3375) : 15.510035 seconds
+Result [pollock-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3375) : 15.518251 seconds
+Result [shark-0] : level-3 : parent(5250, 250, 3250) : (5375, 375, 3375) : 15.654969 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (5375, 375, 3125) 14.741021 seconds
+...done.
+
+OPTIMAL : (5375, 375, 3125) 14.741021 seconds : 11.577669326070877 GFlops/sec
+
+Creating tasks for parent (5750, 250, 3250) ...
+Result [mackerel-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3125) : 14.738212 seconds
+Result [anchovy-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3125) : 14.900494 seconds
+Result [grouper-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3125) : 15.443144 seconds
+Result [blowfish-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3125) : 15.494064 seconds
+Result [swordfish-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3125) : 15.493937 seconds
+Result [brill-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3125) : 14.830316 seconds
+Result [char-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3375) : 14.929838 seconds
+Result [eel-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3375) : 14.972078 seconds
+Result [flounder-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3375) : 14.965437 seconds
+Result [marlin-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3125) : 14.722652 seconds
+Result [cod-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3375) : 14.926276 seconds
+Result [barracuda-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3125) : 14.802324 seconds
+Result [pollock-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3375) : 14.826524 seconds
+Result [sole-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3375) : 16.03272 seconds
+Result [bonito-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3125) : 14.797932 seconds
+Result [dorado-0] : level-3 : parent(5750, 250, 3250) : (5625, 125, 3375) : 14.923785 seconds
+Result [herring-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3125) : 14.87793 seconds
+Result [sardine-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3375) : 15.52994 seconds
+Result [tarpon-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3125) : 15.365656 seconds
+Result [mackerel-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3125) : 14.823687 seconds
+Result [perch-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3375) : 22.229417 seconds
+Result [anchovy-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3375) : 15.583908 seconds
+Result [grouper-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3375) : 15.698124 seconds
+Result [swordfish-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3375) : 15.597017 seconds
+Result [char-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3125) : 14.751281 seconds
+Result [shark-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3375) : 16.330707 seconds
+Result [eel-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3125) : 14.710923 seconds
+Result [brill-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3375) : 14.955567 seconds
+Result [wahoo-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3125) : 14.820046 seconds
+Result [turbot-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3125) : 14.834131 seconds
+Result [marlin-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3125) : 14.797199 seconds
+Result [cod-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3125) : 14.689475 seconds
+Result [flounder-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3125) : 14.693997 seconds
+Result [halibut-0] : level-3 : parent(5750, 250, 3250) : (5625, 375, 3125) : 14.729212 seconds
+Result [barracuda-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3375) : 14.821672 seconds
+Result [pollock-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3375) : 14.861074 seconds
+Result [blowfish-0] : level-3 : parent(5750, 250, 3250) : (5875, 125, 3375) : 14.921019 seconds
+Result [bonito-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3375) : 14.810156 seconds
+Result [dorado-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3375) : 14.88699 seconds
+Result [sole-0] : level-3 : parent(5750, 250, 3250) : (5875, 375, 3375) : 15.882522 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (5875, 375, 3125) 14.728575 seconds
+...done.
+
+OPTIMAL : (5875, 375, 3125) 14.728575 seconds : 11.587452735017926 GFlops/sec
+
+Creating tasks for parent (5250, 250, 3750) ...
+Result [char-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3875) : 14.884378 seconds
+Result [tarpon-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3625) : 15.051633 seconds
+Result [bonito-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3625) : 15.073313 seconds
+Result [cod-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3875) : 14.855859 seconds
+Result [mackerel-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3625) : 14.981847 seconds
+Result [marlin-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3625) : 14.997533 seconds
+Result [sardine-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3875) : 15.18211 seconds
+Result [brill-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3625) : 15.065336 seconds
+Result [anchovy-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3625) : 15.101458 seconds
+Result [sole-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3875) : 16.250988 seconds
+Result [dorado-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3875) : 14.916345 seconds
+Result [flounder-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3875) : 14.890626 seconds
+Result [eel-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3875) : 14.934733 seconds
+Result [shark-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3875) : 16.831866 seconds
+Result [turbot-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3625) : 15.026711 seconds
+Result [grouper-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3625) : 15.637448 seconds
+Result [blowfish-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3625) : 15.100324 seconds
+Result [herring-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3625) : 15.629513 seconds
+Result [wahoo-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3625) : 15.733279 seconds
+Result [halibut-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3625) : 14.941023 seconds
+Result [pollock-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3875) : 15.082176 seconds
+Result [barracuda-0] : level-3 : parent(5250, 250, 3750) : (5125, 125, 3625) : 15.075152 seconds
+Result [swordfish-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3625) : 15.092052 seconds
+Result [char-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3625) : 15.097174 seconds
+Result [bonito-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3875) : 14.875786 seconds
+Result [tarpon-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3875) : 15.575361 seconds
+Result [cod-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3875) : 14.871778 seconds
+Result [mackerel-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3875) : 14.922396 seconds
+Result [marlin-0] : level-3 : parent(5250, 250, 3750) : (5375, 125, 3875) : 14.951972 seconds
+Result [sardine-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3625) : 14.961817 seconds
+Result [perch-0] : level-3 : parent(5250, 250, 3750) : (5125, 375, 3875) : 22.616937 seconds
+Result [brill-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3625) : 15.070268 seconds
+Result [dorado-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3625) : 14.998281 seconds
+Result [anchovy-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3625) : 14.955725 seconds
+Result [eel-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3875) : 15.114434 seconds
+Result [sole-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3625) : 15.89832 seconds
+Result [flounder-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3875) : 15.079011 seconds
+Result [turbot-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3875) : 15.088185 seconds
+Result [shark-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3875) : 15.808613 seconds
+Result [grouper-0] : level-3 : parent(5250, 250, 3750) : (5375, 375, 3875) : 16.573001 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (5125, 125, 3875) 14.8963882 seconds
+...done.
+
+OPTIMAL : (5125, 125, 3875) 14.8963882 seconds : 11.456915889629316 GFlops/sec
+
+Creating tasks for parent (4500, 500, 3500) ...
+Result [bonito-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3250) : 14.750558 seconds
+Result [anchovy-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3250) : 14.799998 seconds
+Result [brill-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3250) : 14.935604 seconds
+Result [grouper-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3250) : 15.661616 seconds
+Result [tarpon-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3250) : 14.824722 seconds
+Result [dorado-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3750) : 15.060236 seconds
+Result [mackerel-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3250) : 15.352721 seconds
+Result [sole-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3750) : 17.659913 seconds
+Result [blowfish-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3250) : 14.786536 seconds
+Result [turbot-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3250) : 14.783889 seconds
+Result [cod-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3750) : 14.971468 seconds
+Result [char-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3750) : 15.033825 seconds
+Result [eel-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3750) : 15.033559 seconds
+Result [barracuda-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3250) : 14.773789 seconds
+Result [herring-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3250) : 15.579486 seconds
+Result [halibut-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3250) : 15.106049 seconds
+Result [sardine-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3750) : 15.668137 seconds
+Result [perch-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3750) : 26.32733 seconds
+Result [wahoo-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3250) : 14.801915 seconds
+Result [flounder-0] : level-2 : parent(4500, 500, 3500) : (4250, 250, 3750) : 14.987071 seconds
+Result [bonito-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3250) : 14.753532 seconds
+Result [anchovy-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3750) : 15.026209 seconds
+Result [brill-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3750) : 15.031115 seconds
+Result [marlin-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3250) : 15.186683 seconds
+Result [grouper-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3750) : 15.846314 seconds
+Result [shark-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3750) : 16.154187 seconds
+Result [tarpon-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3750) : 15.047207 seconds
+Result [dorado-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3750) : 15.001653 seconds
+Result [mackerel-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3250) : 15.161472 seconds
+Result [pollock-0] : level-2 : parent(4500, 500, 3500) : (4250, 750, 3750) : 15.672265 seconds
+Result [swordfish-0] : level-2 : parent(4500, 500, 3500) : (4750, 250, 3250) : 14.807781 seconds
+Result [sole-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3250) : 16.742812 seconds
+Result [blowfish-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3250) : 15.889857 seconds
+Result [turbot-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3250) : 15.13442 seconds
+Result [cod-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3250) : 15.162046 seconds
+Result [char-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3750) : 15.949088 seconds
+Result [eel-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3750) : 15.974186 seconds
+Result [barracuda-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3750) : 15.79342 seconds
+Result [herring-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3750) : 17.055073 seconds
+Result [halibut-0] : level-2 : parent(4500, 500, 3500) : (4750, 750, 3750) : 15.878712 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (4750, 250, 3250) 14.7943678 seconds
+Selected : (4250, 250, 3250) 14.809297 seconds
+Selected : (4250, 250, 3750) 15.0172318 seconds
+...done.
+
+Creating tasks for parent (4750, 250, 3250) ...
+Result [anchovy-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3125) : 14.856517 seconds
+Result [pollock-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3375) : 14.826162 seconds
+Result [char-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3375) : 15.000905 seconds
+Result [grouper-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3125) : 15.119604 seconds
+Result [wahoo-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3125) : 14.824241 seconds
+Result [flounder-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3375) : 14.920677 seconds
+Result [herring-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3125) : 15.746844 seconds
+Result [barracuda-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3125) : 14.833499 seconds
+Result [swordfish-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3125) : 14.808093 seconds
+Result [brill-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3125) : 14.854413 seconds
+Result [blowfish-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3125) : 14.803275 seconds
+Result [bonito-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3125) : 14.917795 seconds
+Result [sole-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3375) : 15.981078 seconds
+Result [eel-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3375) : 14.910059 seconds
+Result [tarpon-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3125) : 14.843445 seconds
+Result [perch-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3375) : 21.653326 seconds
+Result [dorado-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3375) : 14.911559 seconds
+Result [shark-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3375) : 15.520392 seconds
+Result [marlin-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3125) : 14.74328 seconds
+Result [sardine-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3375) : 14.868565 seconds
+Result [turbot-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3125) : 14.783387 seconds
+Result [anchovy-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3125) : 14.81657 seconds
+Result [pollock-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3375) : 14.92391 seconds
+Result [char-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3375) : 14.917877 seconds
+Result [halibut-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3125) : 14.720297 seconds
+Result [grouper-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3375) : 15.422132 seconds
+Result [mackerel-0] : level-3 : parent(4750, 250, 3250) : (4625, 375, 3125) : 14.714865 seconds
+Result [wahoo-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3375) : 15.579513 seconds
+Result [herring-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3125) : 15.418706 seconds
+Result [brill-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3125) : 14.715881 seconds
+Result [flounder-0] : level-3 : parent(4750, 250, 3250) : (4875, 125, 3375) : 14.9353 seconds
+Result [barracuda-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3125) : 15.39587 seconds
+Result [cod-0] : level-3 : parent(4750, 250, 3250) : (4625, 125, 3375) : 14.892319 seconds
+Result [swordfish-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3125) : 14.733284 seconds
+Result [bonito-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3375) : 14.859471 seconds
+Result [blowfish-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3125) : 14.682312 seconds
+Result [tarpon-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3375) : 14.850192 seconds
+Result [sole-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3375) : 15.842929 seconds
+Result [eel-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3375) : 14.830712 seconds
+Result [perch-0] : level-3 : parent(4750, 250, 3250) : (4875, 375, 3375) : 22.10068 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4875, 125, 3125) 14.8151472 seconds
+...done.
+
+OPTIMAL : (4875, 125, 3125) 14.8151472 seconds : 11.519741543078739 GFlops/sec
+
+Creating tasks for parent (4250, 250, 3250) ...
+Result [halibut-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3125) : 14.698083 seconds
+Result [mackerel-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3125) : 14.71068 seconds
+Result [turbot-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3125) : 14.84669 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3375) : 15.816249 seconds
+Result [marlin-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3125) : 14.722359 seconds
+Result [anchovy-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3125) : 14.823553 seconds
+Result [cod-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3375) : 14.920791 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3375) : 14.903258 seconds
+Result [char-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3375) : 14.961906 seconds
+Result [herring-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3125) : 14.885307 seconds
+Result [swordfish-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3125) : 14.821473 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3125) : 15.1724 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3375) : 15.57069 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3125) : 14.81529 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3125) : 14.796415 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3125) : 14.84411 seconds
+Result [bonito-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3125) : 14.792967 seconds
+Result [eel-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3375) : 14.966038 seconds
+Result [wahoo-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3125) : 14.866142 seconds
+Result [perch-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3375) : 22.067944 seconds
+Result [pollock-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3375) : 14.855064 seconds
+Result [shark-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3375) : 16.143813 seconds
+Result [turbot-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3375) : 14.972813 seconds
+Result [halibut-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3125) : 15.490107 seconds
+Result [sardine-0] : level-3 : parent(4250, 250, 3250) : (4125, 375, 3375) : 14.870956 seconds
+Result [cod-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3125) : 14.689635 seconds
+Result [marlin-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3375) : 14.931912 seconds
+Result [anchovy-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3375) : 14.91717 seconds
+Result [char-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3125) : 14.767208 seconds
+Result [mackerel-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3375) : 15.586797 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 3250) : (4375, 125, 3375) : 15.95112 seconds
+Result [swordfish-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3125) : 14.711511 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3125) : 14.720018 seconds
+Result [brill-0] : level-3 : parent(4250, 250, 3250) : (4125, 125, 3125) : 14.799493 seconds
+Result [herring-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3125) : 15.574929 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3375) : 14.84202 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3375) : 16.689479 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3375) : 15.494753 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3375) : 14.852777 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 3250) : (4375, 375, 3375) : 14.862781 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4125, 125, 3125) 14.811307600000001 seconds
+...done.
+
+OPTIMAL : (4125, 125, 3125) 14.811307600000001 seconds : 11.522727856024451 GFlops/sec
+
+Creating tasks for parent (4250, 250, 3750) ...
+Result [cod-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3875) : 14.906259 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3625) : 15.07046 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3875) : 16.201642 seconds
+Result [sardine-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3875) : 15.087845 seconds
+Result [halibut-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3625) : 15.660346 seconds
+Result [char-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3875) : 14.882408 seconds
+Result [wahoo-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3625) : 15.102181 seconds
+Result [brill-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3625) : 15.705382 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3875) : 14.86411 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3625) : 15.320513 seconds
+Result [herring-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3625) : 15.547829 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3875) : 14.882406 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3625) : 15.045526 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3625) : 15.108325 seconds
+Result [shark-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3875) : 15.462272 seconds
+Result [perch-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3875) : 22.787589 seconds
+Result [bonito-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3625) : 15.011545 seconds
+Result [anchovy-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3625) : 15.024249 seconds
+Result [turbot-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3625) : 15.206381 seconds
+Result [mackerel-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3625) : 14.976161 seconds
+Result [pollock-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3875) : 15.166995 seconds
+Result [eel-0] : level-3 : parent(4250, 250, 3750) : (4125, 125, 3875) : 14.877116 seconds
+Result [marlin-0] : level-3 : parent(4250, 250, 3750) : (4125, 375, 3625) : 15.011237 seconds
+Result [cod-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3625) : 15.030976 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3875) : 14.908154 seconds
+Result [swordfish-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3625) : 15.035193 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3875) : 15.785401 seconds
+Result [sardine-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3875) : 14.869347 seconds
+Result [halibut-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3875) : 14.888976 seconds
+Result [char-0] : level-3 : parent(4250, 250, 3750) : (4375, 125, 3875) : 14.87982 seconds
+Result [wahoo-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3625) : 14.957677 seconds
+Result [brill-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3625) : 15.001549 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3625) : 14.951674 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3625) : 15.778702 seconds
+Result [herring-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3625) : 15.939505 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3875) : 15.093427 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3875) : 15.108079 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3875) : 15.114874 seconds
+Result [shark-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3875) : 15.918102 seconds
+Result [perch-0] : level-3 : parent(4250, 250, 3750) : (4375, 375, 3875) : 22.62972 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4125, 125, 3875) 14.8824598 seconds
+...done.
+
+OPTIMAL : (4125, 125, 3875) 14.8824598 seconds : 11.467638344749076 GFlops/sec
+
+Creating tasks for parent (4500, 500, 2500) ...
+Result [anchovy-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2250) : 14.978182 seconds
+Result [turbot-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2250) : 14.951537 seconds
+Result [blowfish-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2250) : 15.040625 seconds
+Result [shark-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2750) : 15.477234 seconds
+Result [barracuda-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2250) : 14.993577 seconds
+Result [halibut-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2250) : 15.084094 seconds
+Result [sole-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2750) : 16.247182 seconds
+Result [cod-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2750) : 14.619102 seconds
+Result [bonito-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2250) : 14.981641 seconds
+Result [swordfish-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2250) : 14.993524 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [dorado-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2750) : 14.624416 seconds
+Result [pollock-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2750) : 14.750266 seconds
+Result [brill-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2250) : 14.998619 seconds
+Result [mackerel-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2250) : 15.158301 seconds
+Result [sardine-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2750) : 14.882389 seconds
+Result [flounder-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2750) : 14.579792 seconds
+Result [wahoo-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2250) : 14.959018 seconds
+Result [marlin-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2250) : 15.176985 seconds
+Result [herring-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2250) : 15.549506 seconds
+Result [perch-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2750) : 24.923212 seconds
+Result [grouper-0] : level-2 : parent(4500, 500, 2500) : (4250, 750, 2250) : 15.440937 seconds
+Result [blowfish-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2750) : 14.601457 seconds
+Result [anchovy-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2250) : 15.011071 seconds
+Result [eel-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2750) : 14.652555 seconds
+Result [shark-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2750) : 15.840459 seconds
+Result [turbot-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2750) : 14.560534 seconds
+Result [halibut-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2750) : 14.578989 seconds
+Result [barracuda-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2750) : 15.277377 seconds
+Result [tarpon-0] : level-2 : parent(4500, 500, 2500) : (4750, 250, 2250) : 15.048776 seconds
+Result [cod-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2250) : 15.09856 seconds
+Result [bonito-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2250) : 15.08587 seconds
+Result [char-0] : level-2 : parent(4500, 500, 2500) : (4250, 250, 2750) : 14.610178 seconds
+Result [swordfish-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2250) : 15.142126 seconds
+Result [sole-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2250) : 16.218861 seconds
+Result [pollock-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2750) : 14.755163 seconds
+Result [mackerel-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2750) : 14.883086 seconds
+Result [dorado-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2250) : 15.767547 seconds
+Result [brill-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2750) : 15.450453 seconds
+Result [sardine-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2750) : 14.772922 seconds
+Result [flounder-0] : level-2 : parent(4500, 500, 2500) : (4750, 750, 2750) : 14.777326 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (4250, 250, 2750) 14.6172086 seconds
+Selected : (4750, 750, 2750) 14.92779 seconds
+Selected : (4750, 250, 2750) 14.9717632 seconds
+...done.
+
+Creating tasks for parent (4250, 250, 2750) ...
+Result [char-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2875) : 14.790843 seconds
+Result [brill-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2625) : 14.968313 seconds
+Result [mackerel-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2625) : 15.032319 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2625) : 15.769965 seconds
+Result [sardine-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2875) : 14.654389 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2875) : 14.731344 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2625) : 14.891843 seconds
+Result [cod-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2875) : 14.741143 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2625) : 14.866906 seconds
+Result [swordfish-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2625) : 14.886082 seconds
+Result [shark-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2875) : 15.084894 seconds
+Result [marlin-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2625) : 15.036179 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2875) : 15.818739 seconds
+Result [turbot-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2625) : 14.901322 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2625) : 14.910207 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2875) : 14.738624 seconds
+Result [anchovy-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2625) : 14.932699 seconds
+Result [eel-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2875) : 14.775057 seconds
+Result [pollock-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2875) : 15.303636 seconds
+Result [herring-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2625) : 15.586483 seconds
+Result [char-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2625) : 14.896232 seconds
+Result [brill-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2875) : 14.827577 seconds
+Result [mackerel-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2875) : 14.835981 seconds
+Result [wahoo-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2625) : 14.952335 seconds
+Result [grouper-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2875) : 15.568069 seconds
+Result [dorado-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2875) : 14.74305 seconds
+Result [barracuda-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2625) : 15.04925 seconds
+Result [sardine-0] : level-3 : parent(4250, 250, 2750) : (4375, 125, 2875) : 15.376201 seconds
+Result [halibut-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2625) : 15.7385 seconds
+Result [cod-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2625) : 15.035822 seconds
+Result [blowfish-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2625) : 15.00619 seconds
+Result [swordfish-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2625) : 15.017682 seconds
+Result [bonito-0] : level-3 : parent(4250, 250, 2750) : (4125, 125, 2625) : 14.918445 seconds
+Result [shark-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2625) : 15.859757 seconds
+Result [marlin-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2875) : 14.669024 seconds
+Result [perch-0] : level-3 : parent(4250, 250, 2750) : (4125, 375, 2875) : 21.746879 seconds
+Result [sole-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2875) : 15.565741 seconds
+Result [turbot-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2875) : 14.620219 seconds
+Result [tarpon-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2875) : 14.680146 seconds
+Result [flounder-0] : level-3 : parent(4250, 250, 2750) : (4375, 375, 2875) : 14.606077 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4125, 125, 2875) 14.7554022 seconds
+...done.
+
+OPTIMAL : (4125, 125, 2875) 14.7554022 seconds : 11.566385270519204 GFlops/sec
+
+Creating tasks for parent (4750, 750, 2750) ...
+Result [char-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2875) : 14.807923 seconds
+Result [dorado-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2875) : 14.764274 seconds
+Result [flounder-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2875) : 15.387824 seconds
+Result [eel-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2875) : 15.40662 seconds
+Result [shark-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2875) : 15.442451 seconds
+Result [sardine-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2875) : 14.984183 seconds
+Result [barracuda-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2625) : 15.240781 seconds
+Result [blowfish-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2625) : 15.249342 seconds
+Result [halibut-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2625) : 15.76777 seconds
+Result [bonito-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2625) : 15.21488 seconds
+Result [brill-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2625) : 15.34897 seconds
+Result [marlin-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2625) : 15.840594 seconds
+Result [anchovy-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2625) : 15.245598 seconds
+Result [wahoo-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2625) : 15.280778 seconds
+Result [mackerel-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2625) : 16.012277 seconds
+Result [sole-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2875) : 16.195062 seconds
+Result [swordfish-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2625) : 15.296111 seconds
+Result [turbot-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2625) : 15.324749 seconds
+Result [dorado-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2875) : 14.755023 seconds
+Result [char-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2625) : 15.311198 seconds
+Result [flounder-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2875) : 14.777224 seconds
+Result [herring-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2625) : 17.240167 seconds
+Result [shark-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2875) : 15.289293 seconds
+Result [perch-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2875) : 25.713024 seconds
+Result [grouper-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2625) : 16.191193 seconds
+Result [sardine-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2875) : 14.695752 seconds
+Result [pollock-0] : level-3 : parent(4750, 750, 2750) : (4625, 875, 2875) : 14.994302 seconds
+Result [tarpon-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2625) : 15.277668 seconds
+Result [barracuda-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2625) : 15.694962 seconds
+Result [blowfish-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2625) : 15.696493 seconds
+Result [halibut-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2625) : 15.748079 seconds
+Result [eel-0] : level-3 : parent(4750, 750, 2750) : (4875, 625, 2875) : 14.765755 seconds
+Result [marlin-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2875) : 15.153132 seconds
+Result [bonito-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2625) : 15.91108 seconds
+Result [brill-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2625) : 15.788877 seconds
+Result [cod-0] : level-3 : parent(4750, 750, 2750) : (4625, 625, 2875) : 14.722235 seconds
+Result [anchovy-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2875) : 15.222111 seconds
+Result [wahoo-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2875) : 14.92916 seconds
+Result [mackerel-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2875) : 15.196376 seconds
+Result [sole-0] : level-3 : parent(4750, 750, 2750) : (4875, 875, 2875) : 16.394374 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4875, 625, 2875) 14.8566094 seconds
+...done.
+
+OPTIMAL : (4875, 625, 2875) 14.8566094 seconds : 11.487591958005348 GFlops/sec
+
+Creating tasks for parent (4750, 250, 2750) ...
+Result [dorado-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2875) : 14.755556 seconds
+Result [eel-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2875) : 14.771478 seconds
+Result [mackerel-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2625) : 15.049464 seconds
+Result [sole-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2875) : 15.83573 seconds
+Result [brill-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2625) : 14.919014 seconds
+Result [tarpon-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2625) : 14.916529 seconds
+Result [anchovy-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2625) : 14.940203 seconds
+Result [flounder-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2875) : 14.715653 seconds
+Warning: No xauth data; using fake authentication data for X11 forwarding.
+Result [cod-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2875) : 14.762214 seconds
+Result [pollock-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2875) : 14.644728 seconds
+Result [bonito-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2625) : 14.911312 seconds
+Result [marlin-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2625) : 15.080055 seconds
+Result [wahoo-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2625) : 14.890268 seconds
+Result [herring-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2625) : 15.411467 seconds
+Result [turbot-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2625) : 15.566089 seconds
+Result [perch-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2875) : 21.822537 seconds
+Result [swordfish-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2625) : 14.923824 seconds
+Result [blowfish-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2625) : 14.947491 seconds
+Result [eel-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2875) : 14.794955 seconds
+Result [mackerel-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2875) : 15.410326 seconds
+Result [shark-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2875) : 15.290891 seconds
+Result [sole-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2875) : 15.857924 seconds
+Result [brill-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2875) : 14.782604 seconds
+Result [tarpon-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2875) : 14.831148 seconds
+Result [dorado-0] : level-3 : parent(4750, 250, 2750) : (4875, 125, 2625) : 15.56049 seconds
+Result [grouper-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2625) : 15.966367 seconds
+Result [flounder-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2625) : 14.998424 seconds
+Result [char-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2875) : 14.72576 seconds
+Result [anchovy-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2625) : 15.132986 seconds
+Result [halibut-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2625) : 15.009984 seconds
+Result [cod-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2625) : 15.03599 seconds
+Result [sardine-0] : level-3 : parent(4750, 250, 2750) : (4625, 375, 2875) : 14.642543 seconds
+Result [pollock-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2625) : 15.01714 seconds
+Result [marlin-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2875) : 14.694196 seconds
+Result [bonito-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2625) : 15.005422 seconds
+Result [barracuda-0] : level-3 : parent(4750, 250, 2750) : (4625, 125, 2625) : 14.903585 seconds
+Result [wahoo-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2875) : 14.6262 seconds
+Result [herring-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2875) : 15.148347 seconds
+Result [turbot-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2875) : 15.297832 seconds
+Result [perch-0] : level-3 : parent(4750, 250, 2750) : (4875, 375, 2875) : 21.774751 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (4625, 125, 2875) 14.7461322 seconds
+...done.
+
+OPTIMAL : (4625, 125, 2875) 14.7461322 seconds : 11.573656356252297 GFlops/sec
+
+Creating tasks for parent (1000, 1000, 3000) ...
+Result [cod-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 3500) : 14.941347 seconds
+Result [anchovy-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 2500) : 15.248826 seconds
+Result [turbot-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 2500) : 15.16576 seconds
+Result [eel-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 3500) : 15.422505 seconds
+Result [flounder-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 3500) : 15.000054 seconds
+Result [halibut-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 2500) : 18.640056 seconds
+Result [dorado-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 3500) : 14.957058 seconds
+Result [char-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 3500) : 14.999243 seconds
+Result [swordfish-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 2500) : 15.206133 seconds
+Result [brill-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 2500) : 15.246371 seconds
+Result [bonito-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 2500) : 15.240171 seconds
+Result [herring-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 2500) : 20.701793 seconds
+Result [grouper-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 2500) : 19.059553 seconds
+Result [barracuda-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 2500) : 15.203346 seconds
+Result [pollock-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 3500) : 18.815064 seconds
+Result [sardine-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 3500) : 18.850657 seconds
+Result [shark-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 3500) : 19.072358 seconds
+Result [blowfish-0] : level-1 : parent(1000, 1000, 3000) : (500, 500, 2500) : 15.1878 seconds
+Result [marlin-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 2500) : 18.906516 seconds
+Result [wahoo-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 2500) : 15.885534 seconds
+Result [cod-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 2500) : 15.146775 seconds
+Result [anchovy-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 3500) : 15.026575 seconds
+Result [tarpon-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 2500) : 15.259555 seconds
+Result [turbot-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 3500) : 15.614969 seconds
+Result [flounder-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 3500) : 14.918454 seconds
+Result [perch-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 3500) : 31.830458 seconds
+Result [halibut-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 3500) : 14.952871 seconds
+Result [mackerel-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 2500) : 18.769537 seconds
+Result [eel-0] : level-1 : parent(1000, 1000, 3000) : (1500, 500, 3500) : 14.969177 seconds
+Result [char-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 2500) : 18.631152 seconds
+Result [dorado-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 2500) : 18.646155 seconds
+Result [swordfish-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 2500) : 18.824248 seconds
+Result [sole-0] : level-1 : parent(1000, 1000, 3000) : (500, 1500, 3500) : 21.122525 seconds
+Result [bonito-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 2500) : 18.616022 seconds
+Result [brill-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 2500) : 18.908693 seconds
+Result [barracuda-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 3500) : 19.050438 seconds
+Result [grouper-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 3500) : 19.229759 seconds
+Result [sardine-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 3500) : 18.847125 seconds
+Result [herring-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 3500) : 23.45198 seconds
+Result [pollock-0] : level-1 : parent(1000, 1000, 3000) : (1500, 1500, 3500) : 18.683637 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (500, 500, 3500) 15.0640414 seconds
+Selected : (1500, 500, 3500) 15.0964092 seconds
+Selected : (500, 500, 2500) 15.2253028 seconds
+...done.
+
+Creating tasks for parent (500, 500, 3500) ...
+Result [anchovy-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3250) : 14.73465 seconds
+Result [halibut-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3250) : 15.152761 seconds
+Result [char-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3750) : 15.700021 seconds
+Result [brill-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3250) : 14.743606 seconds
+Result [swordfish-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3250) : 14.768448 seconds
+Result [pollock-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3750) : 15.588204 seconds
+Result [sole-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3750) : 18.034726 seconds
+Result [blowfish-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3250) : 14.755793 seconds
+Result [dorado-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3750) : 14.990521 seconds
+Result [tarpon-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3250) : 14.733695 seconds
+Result [flounder-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3750) : 14.989416 seconds
+Result [cod-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3750) : 14.971424 seconds
+Result [bonito-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3250) : 14.772833 seconds
+Result [mackerel-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3250) : 15.307106 seconds
+Result [shark-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3750) : 16.301521 seconds
+Result [marlin-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3250) : 15.364837 seconds
+Result [grouper-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3250) : 15.666162 seconds
+Result [herring-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3250) : 17.047148 seconds
+Result [sardine-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3750) : 16.077234 seconds
+Result [turbot-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3250) : 14.788881 seconds
+Result [anchovy-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3250) : 14.804869 seconds
+Result [halibut-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3750) : 14.968896 seconds
+Result [barracuda-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3250) : 14.789552 seconds
+Result [char-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3750) : 14.992212 seconds
+Result [perch-0] : level-2 : parent(500, 500, 3500) : (250, 750, 3750) : 27.496699 seconds
+Result [brill-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3750) : 15.011962 seconds
+Result [swordfish-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3750) : 15.009678 seconds
+Result [eel-0] : level-2 : parent(500, 500, 3500) : (250, 250, 3750) : 15.029158 seconds
+Result [pollock-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3750) : 14.9532 seconds
+Result [blowfish-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3250) : 15.224518 seconds
+Result [dorado-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3250) : 15.123056 seconds
+Result [wahoo-0] : level-2 : parent(500, 500, 3500) : (750, 250, 3250) : 14.759176 seconds
+Result [sole-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3250) : 16.65391 seconds
+Result [flounder-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3250) : 15.150741 seconds
+Result [tarpon-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3250) : 15.4023 seconds
+Result [cod-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3750) : 15.904657 seconds
+Result [bonito-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3750) : 15.892925 seconds
+Result [mackerel-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3750) : 15.999185 seconds
+Result [shark-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3750) : 16.172644 seconds
+Result [marlin-0] : level-2 : parent(500, 500, 3500) : (750, 750, 3750) : 16.122012 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (250, 250, 3250) 14.7592868 seconds
+Selected : (750, 250, 3250) 14.7710138 seconds
+Selected : (750, 250, 3750) 14.9871896 seconds
+...done.
+
+Creating tasks for parent (250, 250, 3250) ...
+Result [bonito-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3125) : 14.69035 seconds
+Result [anchovy-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3125) : 14.799372 seconds
+Result [swordfish-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3125) : 14.762186 seconds
+Result [herring-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3125) : 15.404934 seconds
+Result [brill-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3125) : 14.789459 seconds
+Result [flounder-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3375) : 14.806891 seconds
+Result [char-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3375) : 14.874761 seconds
+Result [eel-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3375) : 15.507899 seconds
+Result [wahoo-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3125) : 14.672625 seconds
+Result [grouper-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3125) : 15.88094 seconds
+Result [sole-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3375) : 16.071429 seconds
+Result [cod-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3375) : 14.792987 seconds
+Result [marlin-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3125) : 14.795696 seconds
+Result [pollock-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3375) : 14.907513 seconds
+Result [shark-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3375) : 15.67913 seconds
+Result [blowfish-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3125) : 14.730303 seconds
+Result [halibut-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3125) : 14.806545 seconds
+Result [sardine-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3375) : 14.930887 seconds
+Result [perch-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3375) : 22.37704 seconds
+Result [turbot-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3125) : 14.662689 seconds
+Result [dorado-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3375) : 14.826317 seconds
+Result [bonito-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3125) : 14.741584 seconds
+Result [swordfish-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3375) : 14.79158 seconds
+Result [mackerel-0] : level-3 : parent(250, 250, 3250) : (125, 375, 3125) : 15.477267 seconds
+Result [herring-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3375) : 16.091542 seconds
+Result [anchovy-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3375) : 14.792993 seconds
+Result [char-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3125) : 14.726568 seconds
+Result [tarpon-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3125) : 14.680845 seconds
+Result [brill-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3375) : 15.455915 seconds
+Result [eel-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3125) : 14.726258 seconds
+Result [flounder-0] : level-3 : parent(250, 250, 3250) : (375, 125, 3375) : 15.454234 seconds
+Result [wahoo-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3125) : 14.736059 seconds
+Result [barracuda-0] : level-3 : parent(250, 250, 3250) : (125, 125, 3125) : 15.40296 seconds
+Result [grouper-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3125) : 15.177581 seconds
+Result [cod-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3375) : 14.87273 seconds
+Result [marlin-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3375) : 14.859661 seconds
+Result [pollock-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3375) : 14.902064 seconds
+Result [sole-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3125) : 15.870833 seconds
+Result [blowfish-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3375) : 14.883277 seconds
+Result [shark-0] : level-3 : parent(250, 250, 3250) : (375, 375, 3375) : 16.355925 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (375, 125, 3125) 14.7039858 seconds
+...done.
+
+OPTIMAL : (375, 125, 3125) 14.7039858 seconds : 11.606830215156128 GFlops/sec
+
+Creating tasks for parent (750, 250, 3250) ...
+Result [barracuda-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3125) : 14.766825 seconds
+Result [char-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3375) : 14.825776 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3375) : 14.866517 seconds
+Result [cod-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3375) : 15.493378 seconds
+Result [shark-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3375) : 15.537784 seconds
+Result [brill-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3125) : 14.765468 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3125) : 14.72953 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3125) : 14.780671 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3125) : 15.317945 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3125) : 14.71892 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3375) : 14.813004 seconds
+Result [eel-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3375) : 14.856958 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3125) : 15.409536 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3375) : 15.474845 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3125) : 14.718477 seconds
+Result [sole-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3375) : 15.786261 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3375) : 14.886218 seconds
+Result [perch-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3375) : 22.24363 seconds
+Result [herring-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3125) : 15.343335 seconds
+Result [char-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3375) : 14.884965 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3375) : 14.877534 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3125) : 15.230107 seconds
+Result [halibut-0] : level-3 : parent(750, 250, 3250) : (625, 375, 3125) : 14.735491 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3125) : 14.793385 seconds
+Result [cod-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3375) : 15.49841 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3125) : 14.734018 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3125) : 14.717174 seconds
+Result [shark-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3375) : 16.188181 seconds
+Result [bonito-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3125) : 14.687804 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3125) : 15.149119 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3125) : 14.735749 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3125) : 14.720902 seconds
+Result [eel-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3375) : 14.836356 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3125) : 14.738251 seconds
+Result [brill-0] : level-3 : parent(750, 250, 3250) : (875, 125, 3375) : 14.890551 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 3250) : (625, 125, 3125) : 14.737426 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3375) : 14.886993 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3375) : 14.843399 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3375) : 14.847666 seconds
+Result [sole-0] : level-3 : parent(750, 250, 3250) : (875, 375, 3375) : 15.961731 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (625, 125, 3125) 14.7352886 seconds
+...done.
+
+OPTIMAL : (625, 125, 3125) 14.7352886 seconds : 11.582173332300167 GFlops/sec
+
+Creating tasks for parent (750, 250, 3750) ...
+Result [char-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3875) : 14.836955 seconds
+Result [eel-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3875) : 14.814328 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3625) : 14.974982 seconds
+Result [shark-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3875) : 16.131535 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3875) : 14.947039 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3625) : 14.959275 seconds
+Result [brill-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3625) : 15.003701 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3625) : 14.977543 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3625) : 15.548597 seconds
+Result [sole-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3875) : 16.111724 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3875) : 14.754948 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3625) : 14.995475 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3625) : 15.026056 seconds
+Result [bonito-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3625) : 14.93042 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3625) : 15.616825 seconds
+Result [perch-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3875) : 23.001202 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3625) : 14.958685 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3625) : 14.961921 seconds
+Result [herring-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3625) : 16.131709 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3875) : 14.823102 seconds
+Result [char-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3625) : 14.986199 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3875) : 15.103403 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3625) : 15.171034 seconds
+Result [eel-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3875) : 14.812819 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3875) : 14.7988 seconds
+Result [shark-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3875) : 15.823825 seconds
+Result [brill-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3625) : 14.981216 seconds
+Result [halibut-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3625) : 14.966834 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 3750) : (625, 375, 3875) : 15.085668 seconds
+Result [cod-0] : level-3 : parent(750, 250, 3750) : (625, 125, 3875) : 14.758628 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3625) : 15.662892 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3625) : 14.988246 seconds
+Result [sole-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3625) : 15.988307 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3875) : 15.121469 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3875) : 15.112381 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3625) : 16.786011 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 3750) : (875, 125, 3875) : 15.492005 seconds
+Result [bonito-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3875) : 15.083312 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3875) : 15.118481 seconds
+Result [perch-0] : level-3 : parent(750, 250, 3750) : (875, 375, 3875) : 22.6679 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (625, 125, 3875) 14.8223796 seconds
+...done.
+
+OPTIMAL : (625, 125, 3875) 14.8223796 seconds : 11.514120625184006 GFlops/sec
+
+Creating tasks for parent (1500, 500, 3500) ...
+Result [bonito-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3250) : 14.757873 seconds
+Result [eel-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3750) : 14.997895 seconds
+Result [cod-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3750) : 15.661735 seconds
+Result [dorado-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3750) : 15.015856 seconds
+Result [grouper-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3250) : 15.491803 seconds
+Result [sole-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3750) : 18.099055 seconds
+Result [wahoo-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3250) : 14.770353 seconds
+Result [mackerel-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3250) : 15.210012 seconds
+Result [blowfish-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3250) : 14.748527 seconds
+Result [herring-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3250) : 17.010512 seconds
+Result [flounder-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3750) : 15.011013 seconds
+Result [marlin-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3250) : 15.184525 seconds
+Result [sardine-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3750) : 15.891662 seconds
+Result [turbot-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3250) : 14.815672 seconds
+Result [tarpon-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3250) : 14.851264 seconds
+Result [swordfish-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3250) : 14.761804 seconds
+Result [shark-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3750) : 16.283366 seconds
+Result [anchovy-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3250) : 14.868493 seconds
+Result [pollock-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3750) : 15.593165 seconds
+Result [char-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3750) : 15.690884 seconds
+Result [bonito-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3250) : 14.749855 seconds
+Result [eel-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3750) : 15.00045 seconds
+Result [perch-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3750) : 26.732956 seconds
+Result [barracuda-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3250) : 14.755271 seconds
+Result [brill-0] : level-2 : parent(1500, 500, 3500) : (1250, 250, 3250) : 14.776222 seconds
+Result [cod-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3750) : 15.003375 seconds
+Result [dorado-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3750) : 15.113829 seconds
+Result [halibut-0] : level-2 : parent(1500, 500, 3500) : (1250, 750, 3250) : 15.137411 seconds
+Result [grouper-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3750) : 15.522014 seconds
+Result [mackerel-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3250) : 15.21035 seconds
+Result [sole-0] : level-2 : parent(1500, 500, 3500) : (1750, 250, 3750) : 15.964886 seconds
+Result [wahoo-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3250) : 14.977441 seconds
+Result [blowfish-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3250) : 15.109446 seconds
+Result [flounder-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3250) : 15.106698 seconds
+Result [herring-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3250) : 15.832486 seconds
+Result [marlin-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3750) : 16.094714 seconds
+Result [sardine-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3750) : 15.810169 seconds
+Result [turbot-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3750) : 16.101841 seconds
+Result [tarpon-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3750) : 16.309294 seconds
+Result [swordfish-0] : level-2 : parent(1500, 500, 3500) : (1750, 750, 3750) : 16.169107 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (1250, 250, 3250) 14.7812772 seconds
+Selected : (1750, 250, 3250) 14.7897896 seconds
+Selected : (1750, 750, 3250) 15.2472842 seconds
+...done.
+
+Creating tasks for parent (1250, 250, 3250) ...
+Result [anchovy-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3125) : 14.849335 seconds
+Result [swordfish-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3125) : 14.762157 seconds
+Result [dorado-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3375) : 14.884893 seconds
+Result [halibut-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3125) : 14.722352 seconds
+Result [char-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3375) : 14.872804 seconds
+Result [eel-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3375) : 14.9043 seconds
+Result [herring-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3125) : 15.8624 seconds
+Result [bonito-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3125) : 14.741981 seconds
+Result [flounder-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3375) : 14.979977 seconds
+Result [grouper-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3125) : 15.380902 seconds
+/usr/bin/xauth:  timeout in locking authority file /s/bach/g/under/lnarmour/.Xauthority
+Result [barracuda-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3125) : 14.762407 seconds
+Result [sardine-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3375) : 14.821511 seconds
+Result [turbot-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3125) : 14.925961 seconds
+Result [wahoo-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3125) : 14.766028 seconds
+Result [tarpon-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3125) : 14.774969 seconds
+Result [shark-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3375) : 15.397599 seconds
+Result [blowfish-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3125) : 14.73646 seconds
+Result [marlin-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3125) : 14.748903 seconds
+Result [mackerel-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3125) : 14.722726 seconds
+Result [pollock-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3375) : 14.879654 seconds
+Result [anchovy-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3125) : 14.768089 seconds
+Result [perch-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3375) : 22.209018 seconds
+Result [dorado-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3375) : 14.909795 seconds
+Result [cod-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3375) : 14.820997 seconds
+Result [swordfish-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3375) : 14.858319 seconds
+Result [halibut-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3375) : 14.879021 seconds
+Result [eel-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3375) : 15.549383 seconds
+Result [herring-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3125) : 15.257178 seconds
+Result [sole-0] : level-3 : parent(1250, 250, 3250) : (1125, 375, 3375) : 15.8104 seconds
+Result [bonito-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3125) : 14.778421 seconds
+Result [char-0] : level-3 : parent(1250, 250, 3250) : (1375, 125, 3375) : 14.905804 seconds
+Result [brill-0] : level-3 : parent(1250, 250, 3250) : (1125, 125, 3125) : 14.745773 seconds
+Result [flounder-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3125) : 15.352715 seconds
+Result [grouper-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3125) : 15.018163 seconds
+Result [barracuda-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3125) : 14.693095 seconds
+Result [sardine-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3375) : 14.858281 seconds
+Result [turbot-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3375) : 14.881484 seconds
+Result [wahoo-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3375) : 14.853593 seconds
+Result [tarpon-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3375) : 14.856411 seconds
+Result [shark-0] : level-3 : parent(1250, 250, 3250) : (1375, 375, 3375) : 15.191332 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1125, 125, 3125) 14.7671912 seconds
+...done.
+
+OPTIMAL : (1125, 125, 3125) 14.7671912 seconds : 11.557151550029817 GFlops/sec
+
+Creating tasks for parent (1750, 250, 3250) ...
+Result [barracuda-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3125) : 14.770241 seconds
+Result [bonito-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3125) : 14.756145 seconds
+Result [anchovy-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3125) : 14.843584 seconds
+Result [mackerel-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3125) : 14.788874 seconds
+Result [swordfish-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3125) : 14.815974 seconds
+Result [halibut-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3125) : 14.687707 seconds
+Result [turbot-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3125) : 14.807414 seconds
+Result [cod-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3375) : 14.907003 seconds
+Result [shark-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3375) : 16.704281 seconds
+Result [brill-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3125) : 14.807721 seconds
+Result [sardine-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3375) : 14.827314 seconds
+Result [sole-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3375) : 15.831126 seconds
+Result [wahoo-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3125) : 14.808527 seconds
+Result [flounder-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3375) : 14.89165 seconds
+Result [perch-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3375) : 21.938071 seconds
+Result [grouper-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3125) : 16.35103 seconds
+Result [pollock-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3375) : 14.816517 seconds
+Result [char-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3375) : 14.884172 seconds
+Result [herring-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3125) : 15.564418 seconds
+Result [marlin-0] : level-3 : parent(1750, 250, 3250) : (1625, 375, 3125) : 14.706625 seconds
+Result [tarpon-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3125) : 15.45905 seconds
+Result [eel-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3375) : 14.906561 seconds
+Result [blowfish-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3125) : 14.832665 seconds
+Result [bonito-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3375) : 14.883156 seconds
+Result [anchovy-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3375) : 14.941551 seconds
+Result [mackerel-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3375) : 14.962918 seconds
+Result [dorado-0] : level-3 : parent(1750, 250, 3250) : (1625, 125, 3375) : 14.897681 seconds
+Result [barracuda-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3125) : 14.782717 seconds
+Result [halibut-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3375) : 14.86625 seconds
+Result [cod-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3125) : 14.693917 seconds
+Result [swordfish-0] : level-3 : parent(1750, 250, 3250) : (1875, 125, 3375) : 14.908797 seconds
+Result [turbot-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3125) : 14.742211 seconds
+Result [sardine-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3125) : 14.73095 seconds
+Result [shark-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3125) : 15.453028 seconds
+Result [brill-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3125) : 14.718383 seconds
+Result [wahoo-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3375) : 14.877051 seconds
+Result [flounder-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3375) : 14.84183 seconds
+Result [sole-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3375) : 16.053509 seconds
+Result [grouper-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3375) : 15.516539 seconds
+Result [perch-0] : level-3 : parent(1750, 250, 3250) : (1875, 375, 3375) : 22.131053 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1625, 125, 3125) 14.8020712 seconds
+...done.
+
+OPTIMAL : (1625, 125, 3125) 14.8020712 seconds : 11.529917966255065 GFlops/sec
+
+Creating tasks for parent (1750, 750, 3250) ...
+Result [anchovy-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3125) : 15.049485 seconds
+Result [mackerel-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3125) : 15.368307 seconds
+Result [barracuda-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3125) : 14.800991 seconds
+Result [brill-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3125) : 14.90343 seconds
+Result [turbot-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3125) : 14.84193 seconds
+Result [char-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3375) : 14.994405 seconds
+Result [dorado-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3375) : 15.086908 seconds
+Result [halibut-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3125) : 15.278959 seconds
+Result [marlin-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3125) : 15.435958 seconds
+Result [cod-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3375) : 15.652099 seconds
+Result [grouper-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3125) : 15.743677 seconds
+Result [bonito-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3125) : 14.823465 seconds
+Result [tarpon-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3125) : 14.939918 seconds
+Result [eel-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3375) : 15.045776 seconds
+Result [sole-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3375) : 17.182014 seconds
+Result [perch-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3375) : 25.58162 seconds
+Result [sardine-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3375) : 15.915071 seconds
+Result [blowfish-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3125) : 14.827114 seconds
+Result [swordfish-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3125) : 14.860224 seconds
+Result [shark-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3375) : 16.208822 seconds
+Result [anchovy-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3125) : 14.875371 seconds
+Result [mackerel-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3375) : 15.085212 seconds
+Result [barracuda-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3375) : 14.921928 seconds
+Result [turbot-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3375) : 15.03859 seconds
+Result [char-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3375) : 15.033197 seconds
+Result [herring-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3125) : 17.55913 seconds
+Result [pollock-0] : level-3 : parent(1750, 750, 3250) : (1625, 875, 3375) : 16.270262 seconds
+Result [brill-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3375) : 14.992587 seconds
+Result [wahoo-0] : level-3 : parent(1750, 750, 3250) : (1875, 625, 3125) : 14.843912 seconds
+Result [dorado-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3125) : 15.313638 seconds
+Result [halibut-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3125) : 15.288796 seconds
+Result [cod-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3125) : 15.259185 seconds
+Result [grouper-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3125) : 15.742347 seconds
+Result [marlin-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3125) : 16.010566 seconds
+Result [flounder-0] : level-3 : parent(1750, 750, 3250) : (1625, 625, 3375) : 14.992432 seconds
+Result [bonito-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3375) : 15.763507 seconds
+Result [tarpon-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3375) : 15.836934 seconds
+Result [eel-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3375) : 15.758487 seconds
+Result [sole-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3375) : 17.184498 seconds
+Result [perch-0] : level-3 : parent(1750, 750, 3250) : (1875, 875, 3375) : 26.09493 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (1875, 625, 3125) 14.872271 seconds
+...done.
+
+OPTIMAL : (1875, 625, 3125) 14.872271 seconds : 11.475494675067894 GFlops/sec
+
+Creating tasks for parent (500, 500, 2500) ...
+Result [dorado-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2750) : 14.590053 seconds
+Result [pollock-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2750) : 14.903668 seconds
+Result [swordfish-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2250) : 14.939633 seconds
+Result [eel-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2750) : 15.264903 seconds
+Result [bonito-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2250) : 15.605215 seconds
+Result [marlin-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2250) : 15.844098 seconds
+Result [flounder-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2750) : 14.564344 seconds
+Result [char-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2750) : 14.762761 seconds
+Result [shark-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2750) : 15.377315 seconds
+Result [mackerel-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2250) : 15.833018 seconds
+Result [blowfish-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2250) : 14.979241 seconds
+Result [herring-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2250) : 16.052093 seconds
+Result [anchovy-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2250) : 14.950977 seconds
+Result [wahoo-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2250) : 14.92808 seconds
+Result [cod-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2750) : 14.559674 seconds
+Result [tarpon-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2250) : 15.008307 seconds
+Result [halibut-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2250) : 15.171696 seconds
+Result [turbot-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2250) : 14.895627 seconds
+Result [grouper-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2250) : 15.659663 seconds
+Result [sardine-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2750) : 14.860625 seconds
+Result [barracuda-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2250) : 14.94726 seconds
+Result [sole-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2750) : 16.029612 seconds
+Result [brill-0] : level-2 : parent(500, 500, 2500) : (250, 250, 2250) : 14.954572 seconds
+Result [dorado-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2250) : 14.941635 seconds
+Result [pollock-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2750) : 14.546147 seconds
+Result [swordfish-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2750) : 14.579307 seconds
+Result [eel-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2750) : 14.583724 seconds
+Result [perch-0] : level-2 : parent(500, 500, 2500) : (250, 750, 2750) : 24.554191 seconds
+Result [bonito-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2750) : 14.582154 seconds
+Result [marlin-0] : level-2 : parent(500, 500, 2500) : (750, 250, 2750) : 14.922728 seconds
+Result [flounder-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2250) : 15.159039 seconds
+Result [char-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2250) : 15.26673 seconds
+Result [mackerel-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2250) : 15.185667 seconds
+Result [shark-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2250) : 16.140057 seconds
+Result [blowfish-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2250) : 15.124806 seconds
+Result [wahoo-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2750) : 14.785804 seconds
+Result [anchovy-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2750) : 14.912572 seconds
+Result [herring-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2750) : 15.921089 seconds
+Result [cod-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2750) : 14.769717 seconds
+Result [tarpon-0] : level-2 : parent(500, 500, 2500) : (750, 750, 2750) : 14.916405 seconds
+...done.
+
+Choosing best 3 results...
+Selected : (750, 250, 2750) 14.642812 seconds
+Selected : (250, 250, 2750) 14.748346999999999 seconds
+Selected : (750, 250, 2250) 14.9426564 seconds
+...done.
+
+Creating tasks for parent (750, 250, 2750) ...
+Result [cod-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2875) : 14.600757 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2625) : 14.850594 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2625) : 14.865499 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2625) : 15.013683 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2875) : 14.633635 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2625) : 14.788022 seconds
+Result [sole-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2875) : 15.603944 seconds
+Result [shark-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2875) : 16.062591 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2875) : 14.593399 seconds
+Result [brill-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2625) : 14.772208 seconds
+Result [halibut-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2625) : 15.719438 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2875) : 14.630752 seconds
+Result [eel-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2875) : 14.680401 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2875) : 14.783237 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2625) : 14.828772 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2625) : 15.14883 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2625) : 15.412193 seconds
+Result [char-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2875) : 14.661142 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2625) : 14.766347 seconds
+Result [herring-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2625) : 15.440642 seconds
+Result [bonito-0] : level-3 : parent(750, 250, 2750) : (625, 125, 2625) : 14.778963 seconds
+Result [perch-0] : level-3 : parent(750, 250, 2750) : (625, 375, 2875) : 21.682994 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2625) : 14.798273 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2875) : 14.67072 seconds
+Result [cod-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2625) : 15.470962 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2625) : 14.802023 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2875) : 15.326896 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2875) : 15.325839 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2875) : 14.666951 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 2750) : (875, 125, 2875) : 14.790119 seconds
+Result [shark-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2625) : 15.455253 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2625) : 15.029474 seconds
+Result [brill-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2625) : 15.046737 seconds
+Result [sole-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2625) : 16.218382 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2875) : 14.629709 seconds
+Result [halibut-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2625) : 15.657929 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2875) : 14.634343 seconds
+Result [eel-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2875) : 15.290204 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2875) : 14.654603 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 2750) : (875, 375, 2875) : 15.309977 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (625, 125, 2875) 14.6413374 seconds
+...done.
+
+OPTIMAL : (625, 125, 2875) 14.6413374 seconds : 11.656494349120502 GFlops/sec
+
+Creating tasks for parent (250, 250, 2750) ...
+Result [dorado-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2875) : 14.648857 seconds
+Result [sardine-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2875) : 14.695646 seconds
+Result [barracuda-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2625) : 14.841248 seconds
+Result [herring-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2625) : 15.823836 seconds
+Result [flounder-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2875) : 14.623879 seconds
+Result [char-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2875) : 14.785384 seconds
+Result [sole-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2875) : 15.710101 seconds
+Result [grouper-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2625) : 15.96593 seconds
+Result [blowfish-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2625) : 14.791697 seconds
+Result [mackerel-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2625) : 15.120097 seconds
+Result [anchovy-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2625) : 14.791686 seconds
+Result [halibut-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2625) : 15.091812 seconds
+Result [brill-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2625) : 14.793091 seconds
+Result [eel-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2875) : 14.644644 seconds
+Result [cod-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2875) : 14.653709 seconds
+Result [shark-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2875) : 15.081002 seconds
+Result [marlin-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2625) : 15.127881 seconds
+Result [perch-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2875) : 21.84053 seconds
+Result [bonito-0] : level-3 : parent(250, 250, 2750) : (125, 125, 2625) : 14.76146 seconds
+Result [sardine-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2875) : 14.580982 seconds
+Result [dorado-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2625) : 14.808735 seconds
+Result [barracuda-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2875) : 14.609232 seconds
+Result [herring-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2875) : 14.777992 seconds
+Result [pollock-0] : level-3 : parent(250, 250, 2750) : (125, 375, 2875) : 15.391026 seconds
+Result [flounder-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2875) : 14.590553 seconds
+Result [char-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2875) : 15.273444 seconds
+Result [tarpon-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2625) : 14.828821 seconds
+Result [grouper-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2625) : 15.649874 seconds
+Result [blowfish-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2625) : 15.031766 seconds
+Result [sole-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2625) : 15.962378 seconds
+Result [turbot-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2625) : 14.729032 seconds
+Result [mackerel-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2625) : 15.02863 seconds
+Result [halibut-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2875) : 14.624043 seconds
+Result [anchovy-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2625) : 15.014882 seconds
+Result [swordfish-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2625) : 14.729915 seconds
+Result [brill-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2875) : 14.664754 seconds
+Result [wahoo-0] : level-3 : parent(250, 250, 2750) : (375, 125, 2625) : 14.730323 seconds
+Result [cod-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2875) : 14.665089 seconds
+Result [eel-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2875) : 14.635612 seconds
+Result [shark-0] : level-3 : parent(250, 250, 2750) : (375, 375, 2875) : 16.407117 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (125, 125, 2875) 14.6712946 seconds
+...done.
+
+OPTIMAL : (125, 125, 2875) 14.6712946 seconds : 11.632693045824782 GFlops/sec
+
+Creating tasks for parent (750, 250, 2250) ...
+Result [bonito-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2125) : 14.855525 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2125) : 14.91952 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2375) : 15.054226 seconds
+Result [eel-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2375) : 15.067727 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2125) : 14.864957 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2375) : 15.081296 seconds
+Result [char-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2375) : 15.720429 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2375) : 15.061751 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2125) : 16.283654 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2125) : 14.90057 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2375) : 15.047767 seconds
+Result [brill-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2125) : 14.862794 seconds
+Result [shark-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2375) : 16.148033 seconds
+Result [sole-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2375) : 16.127688 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2125) : 14.88932 seconds
+Result [perch-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2375) : 22.149293 seconds
+Result [swordfish-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2125) : 14.887495 seconds
+Result [cod-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2375) : 15.03323 seconds
+Result [anchovy-0] : level-3 : parent(750, 250, 2250) : (625, 125, 2125) : 14.910996 seconds
+Result [herring-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2125) : 15.05938 seconds
+Result [bonito-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2125) : 14.854983 seconds
+Result [wahoo-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2375) : 15.108553 seconds
+Result [eel-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2375) : 15.080018 seconds
+Result [halibut-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2125) : 14.856985 seconds
+Result [barracuda-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2375) : 15.044526 seconds
+Result [dorado-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2375) : 15.057751 seconds
+Result [flounder-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2375) : 15.027434 seconds
+Result [tarpon-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2125) : 14.913711 seconds
+Result [char-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2125) : 15.547786 seconds
+Result [sardine-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2125) : 15.019863 seconds
+Result [mackerel-0] : level-3 : parent(750, 250, 2250) : (625, 375, 2125) : 14.885042 seconds
+Result [grouper-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2125) : 15.335564 seconds
+Result [marlin-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2125) : 14.859855 seconds
+Result [pollock-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2125) : 14.831119 seconds
+Result [turbot-0] : level-3 : parent(750, 250, 2250) : (875, 125, 2125) : 14.85227 seconds
+Result [brill-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2375) : 15.026598 seconds
+Result [blowfish-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2375) : 15.062394 seconds
+Result [sole-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2375) : 16.010099 seconds
+Result [shark-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2375) : 16.797429 seconds
+Result [perch-0] : level-3 : parent(750, 250, 2250) : (875, 375, 2375) : 22.276135 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (625, 125, 2125) 14.8767184 seconds
+...done.
+
+OPTIMAL : (625, 125, 2125) 14.8767184 seconds : 11.472064072051445 GFlops/sec

--- a/results/experiment-test.log
+++ b/results/experiment-test.log
@@ -1,0 +1,154 @@
+args : {'N': 500, 'path_prefix': './workspace/parric-ttmm/ttmm/ikj/out', 'keep': [2, 1], 'partitions': [2, 2], 'parent_center': (50, 50, 50), 'parent_size': 100, 'iterations': 2}
+
+Creating Machine('anchovy')...done.
+Creating Machine('barracuda')...done.
+Creating Machine('blowfish')...done.
+Creating Machine('bonito')...done.
+Creating Machine('brill')...done.
+Creating Machine('char')...done.
+
+Creating tasks for parent (50, 50, 50) ...
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 25, 25) : 0.017652 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 25, 25) : 0.015174 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 25, 75) : 0.013676 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 25, 75) : 0.013277 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 25, 75) : 0.012437 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 25, 75) : 0.01245 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 75, 25) : 0.018284 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 75, 25) : 0.026676 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (25, 25, 75) : 0.011013 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (25, 25, 25) : 0.019211 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 75, 25) : 0.016048 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 75, 25) : 0.01598 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (25, 75, 25) : 0.016477 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (25, 75, 75) : 0.013784 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (25, 75, 75) : 0.013602 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (25, 75, 75) : 0.010885 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (25, 75, 75) : 0.010049 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (25, 75, 75) : 0.01386 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (75, 25, 25) : 0.016999 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (75, 25, 25) : 0.019644 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (75, 25, 25) : 0.018803 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (75, 25, 25) : 0.019399 seconds
+Result [bonito-0] : level-0 : parent(50, 50, 50) : (25, 25, 25) : 0.015771 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (75, 25, 75) : 0.016712 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (75, 25, 75) : 0.016085 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (75, 25, 75) : 0.011388 seconds
+Result [bonito-0] : level-0 : parent(50, 50, 50) : (75, 25, 75) : 0.014753 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (75, 25, 75) : 0.013445 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (75, 75, 25) : 0.014789 seconds
+Result [bonito-0] : level-0 : parent(50, 50, 50) : (75, 75, 25) : 0.01871 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (75, 25, 25) : 0.018194 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (75, 75, 25) : 0.017924 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (75, 75, 25) : 0.016124 seconds
+Result [bonito-0] : level-0 : parent(50, 50, 50) : (75, 75, 75) : 0.012457 seconds
+Result [brill-0] : level-0 : parent(50, 50, 50) : (75, 75, 75) : 0.011001 seconds
+Result [char-0] : level-0 : parent(50, 50, 50) : (75, 75, 75) : 0.013961 seconds
+Result [blowfish-0] : level-0 : parent(50, 50, 50) : (25, 25, 25) : 0.019056 seconds
+Result [bonito-0] : level-0 : parent(50, 50, 50) : (75, 75, 75) : 0.01397 seconds
+Result [anchovy-0] : level-0 : parent(50, 50, 50) : (75, 75, 25) : 0.016288 seconds
+Result [barracuda-0] : level-0 : parent(50, 50, 50) : (75, 75, 75) : 0.010629 seconds
+...done.
+
+Choosing best 2 results...
+Selected : (75, 75, 75) 0.012403599999999999 seconds
+Selected : (25, 75, 75) 0.012436000000000001 seconds
+...done.
+
+Creating tasks for parent (75, 75, 75) ...
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 62, 62) : 0.013308 seconds
+Result [brill-0] : level-1 : parent(75, 75, 75) : (62, 62, 62) : 0.014245 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 62, 87) : 0.013529 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 62, 87) : 0.017782 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 62, 87) : 0.011331 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (62, 62, 87) : 0.009231 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 87, 62) : 0.014583 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (62, 87, 62) : 0.011328 seconds
+Result [brill-0] : level-1 : parent(75, 75, 75) : (62, 62, 87) : 0.010257 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 87, 62) : 0.014247 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (62, 87, 62) : 0.014912 seconds
+Result [brill-0] : level-1 : parent(75, 75, 75) : (62, 87, 62) : 0.012591 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 87, 87) : 0.013243 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (62, 87, 87) : 0.01853 seconds
+Result [brill-0] : level-1 : parent(75, 75, 75) : (62, 87, 87) : 0.012551 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (62, 87, 87) : 0.009969 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (62, 62, 62) : 0.021836 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (62, 87, 87) : 0.011707 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 62, 62) : 0.014217 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 62, 62) : 0.014609 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (87, 62, 62) : 0.011656 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 62, 62) : 0.013934 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 62, 87) : 0.011644 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (87, 62, 87) : 0.009252 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 62, 87) : 0.013569 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 62, 87) : 0.018825 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (87, 62, 87) : 0.013697 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 87, 62) : 0.012323 seconds
+Result [barracuda-0] : level-1 : parent(75, 75, 75) : (62, 62, 62) : 0.011989 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 87, 62) : 0.015621 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (87, 87, 62) : 0.012603 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 87, 62) : 0.012808 seconds
+Result [barracuda-0] : level-1 : parent(75, 75, 75) : (87, 87, 62) : 0.014736 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 87, 87) : 0.012994 seconds
+Result [blowfish-0] : level-1 : parent(75, 75, 75) : (87, 87, 87) : 0.012743 seconds
+Result [barracuda-0] : level-1 : parent(75, 75, 75) : (87, 87, 87) : 0.01019 seconds
+Result [bonito-0] : level-1 : parent(75, 75, 75) : (87, 87, 87) : 0.011679 seconds
+Result [anchovy-0] : level-1 : parent(75, 75, 75) : (62, 62, 62) : 0.014214 seconds
+Result [brill-0] : level-1 : parent(75, 75, 75) : (87, 62, 62) : 0.012051 seconds
+Result [char-0] : level-1 : parent(75, 75, 75) : (87, 87, 87) : 0.013222 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (87, 87, 87) 0.0121656 seconds
+...done.
+
+OPTIMAL : (87, 87, 87) 0.0121656 seconds : 3.424957804519848 GFlops/sec
+
+Creating tasks for parent (25, 75, 75) ...
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 62, 62) : 0.013277 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (12, 62, 62) : 0.015161 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 62, 87) : 0.013562 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 62, 87) : 0.016007 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (12, 62, 87) : 0.010228 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 62, 87) : 0.012183 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 62, 87) : 0.013534 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 87, 62) : 0.014813 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 87, 62) : 0.01466 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 87, 62) : 0.010072 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (12, 62, 62) : 0.011389 seconds
+Result [blowfish-0] : level-1 : parent(25, 75, 75) : (12, 62, 62) : 0.012187 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 87, 62) : 0.012127 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 87, 87) : 0.011306 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (12, 87, 87) : 0.013481 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (12, 87, 87) : 0.013923 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (12, 87, 87) : 0.013291 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 62, 62) : 0.010013 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (12, 87, 62) : 0.012368 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 62, 62) : 0.01073 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 62, 62) : 0.012078 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (37, 62, 62) : 0.014307 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 62, 87) : 0.013401 seconds
+Result [barracuda-0] : level-1 : parent(25, 75, 75) : (12, 62, 62) : 0.012935 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 62, 87) : 0.01363 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (37, 62, 87) : 0.013124 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 62, 87) : 0.013112 seconds
+Result [barracuda-0] : level-1 : parent(25, 75, 75) : (37, 62, 87) : 0.009812 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 87, 62) : 0.013645 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 87, 62) : 0.011959 seconds
+Result [barracuda-0] : level-1 : parent(25, 75, 75) : (37, 87, 62) : 0.014986 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 87, 62) : 0.01717 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 87, 87) : 0.011916 seconds
+Result [barracuda-0] : level-1 : parent(25, 75, 75) : (37, 87, 87) : 0.013326 seconds
+Result [brill-0] : level-1 : parent(25, 75, 75) : (37, 87, 87) : 0.016463 seconds
+Result [char-0] : level-1 : parent(25, 75, 75) : (37, 87, 87) : 0.01369 seconds
+Result [barracuda-0] : level-1 : parent(25, 75, 75) : (37, 87, 87) : 0.011139 seconds
+Result [blowfish-0] : level-1 : parent(25, 75, 75) : (12, 87, 87) : 0.011971 seconds
+Result [bonito-0] : level-1 : parent(25, 75, 75) : (37, 87, 62) : 0.011867 seconds
+Result [anchovy-0] : level-1 : parent(25, 75, 75) : (37, 62, 62) : 0.014376 seconds
+...done.
+
+Choosing best 1 results...
+Selected : (37, 62, 62) 0.0123008 seconds
+...done.
+
+OPTIMAL : (37, 62, 62) 0.0123008 seconds : 3.3873135622615327 GFlops/sec

--- a/scripts/experiment-0.sh
+++ b/scripts/experiment-0.sh
@@ -1,0 +1,11 @@
+echo 'unbuffer python3 commander.py -N 5000 -i 4 --partitions 4 2 2 2 -k 3 3 3 1 --path-prefix ./workspace/parric-ttmm/ttmm/ikj/out | tee -a ~/workspace/parric-ttmm/results/experiment-0.log'
+echo ''
+
+unbuffer \
+python3 commander.py \
+-N 5000 \
+-i 4 \
+--partitions 4 2 2 2 \
+-k 3 3 3 1 \
+--path-prefix ./workspace/parric-ttmm/ttmm/ikj/out \
+| tee -a ~/workspace/parric-ttmm/results/experiment-0.log

--- a/scripts/experiment-1.sh
+++ b/scripts/experiment-1.sh
@@ -1,0 +1,11 @@
+echo 'unbuffer python3 commander.py -N 8000 -i 4 --partitions 4 2 2 2 -k 3 3 3 1 --path-prefix ./workspace/parric-ttmm/ttmm/ikj/out | tee -a ~/workspace/parric-ttmm/results/experiment-1.log'
+echo ''
+
+unbuffer \
+python3 commander.py \
+-N 8000 \
+-i 4 \
+--partitions 4 2 2 2 \
+-k 3 3 3 1 \
+--path-prefix ./workspace/parric-ttmm/ttmm/ikj/out \
+| tee -a ~/workspace/parric-ttmm/results/experiment-1.log

--- a/scripts/experiment-20180804.sh
+++ b/scripts/experiment-20180804.sh
@@ -1,0 +1,13 @@
+echo 'unbuffer python3 commander.py -N 5000 --parent-center 500 500 500 --parent-size 1000 -i 4 --partitions 4 4 4 4 -k 16 4 2 2 --path-prefix ./workspace/parric-ttmm/ttmm/ikj/out | tee -a ~/workspace/parric-ttmm/results/experiment-20180804.log'
+echo ''
+
+unbuffer \
+python3 commander.py \
+-N 5000 \
+--parent-center 500 500 500 \
+--parent-size 1000 \
+-i 4 \
+--partitions 4 4 4 4 \
+-k 16 4 2 2 \
+--path-prefix ./workspace/parric-ttmm/ttmm/ikj/out \
+| tee -a ~/workspace/parric-ttmm/results/experiment-20180804.log

--- a/scripts/experiment-test.sh
+++ b/scripts/experiment-test.sh
@@ -1,0 +1,13 @@
+echo 'unbuffer python3 commander.py -N 500 --parent-center 50 50 50 --parent-size 100 -i 2 --partitions 2 2 -k 2 1 --path-prefix ./workspace/parric-ttmm/ttmm/ikj/out | tee -a ~/workspace/parric-ttmm/results/experiment-test.log'
+echo ''
+
+unbuffer \
+python3 commander.py \
+-N 500 \
+--parent-center 50 50 50 \
+--parent-size 100 \
+-i 2 \
+--partitions 2 2 \
+-k 2 1 \
+--path-prefix ./workspace/parric-ttmm/ttmm/ikj/out \
+| tee -a ~/workspace/parric-ttmm/results/experiment-test.log


### PR DESCRIPTION
Now we can properly invoke commander.py from bash.  Also if we pass the entire invocation to ```unbuffer``` then pipe to ```tee -a```, then the output will be directed to stdout AND appended to a file simultaneously.

Example usage based on the experiment we plan to run:
```
$ unbuffer \
python3 commander.py \
-N 5000 \
--parent-center 500 500 500 \
--parent-size 1000 \
-i 4 \
--partitions 4 4 4 4 \
-k 16 4 2 2 \
--path-prefix ./workspace/parric-ttmm/ttmm/ikj/out \
| tee -a ~/workspace/parric-ttmm/results/ttmm5000.log
```
------------
As a test:
```
$ ./experiment-test.sh
```

Can monitor with:
```
$ watch -n 5 'cat experiment-test.log | grep args && echo '' && cat experiment-test.log | grep OPTIMAL'
```

Which updates as it completes:
```
Every 5.0s: cat experiment-test.log | grep args && echo ...  Fri Aug  3 12:46:52 2018

args : {'N': 500, 'path_prefix': './workspace/parric-ttmm/ttmm/ikj/out', 'keep': [2,
1], 'partitions': [2, 2], 'parent_center': (50, 50, 50), 'parent_size': 100, 'iterati
ons': 2}

OPTIMAL : (87, 87, 87) 0.0121656 seconds : 3.424957804519848 GFlops/sec
OPTIMAL : (37, 62, 62) 0.0123008 seconds : 3.3873135622615327 GFlops/sec
```