### PR TITLE
Added K loop reductions.

### DIFF
--- a/parallelTests/ijk/out/thirdLoop/TMM.c
+++ b/parallelTests/ijk/out/thirdLoop/TMM.c
@@ -100,8 +100,27 @@ inline double __min_double(double x, double y){
 	return ((x)>(y) ? (y) : (x));
 }
 
+int N;
 
+float ** initialize_R ( ){
+    float * temp = malloc(sizeof(float)*(N+1)*(N+1));
+    float ** new_R = malloc(sizeof(float*)*(N+1));
+    for(int i = 0; i < N+1; i++){
+        new_R[i]=temp+(N+1)*i;
+        for(int j = 0; j < N+1; j++){
+            temp[i*(N+1)+j] = 0;
+        }
+    }
+    return new_R;
+}
 
+void combine_R( float ** omp_in, float ** omp_out){
+    for (int i = 0; i <= N; i++)
+        for (int j = i; j <= N; j++)
+            omp_out[i][j] += omp_in[i][j];
+    free(omp_in[0]);
+    free(omp_in);
+}
 
 
 
@@ -111,16 +130,17 @@ inline double __min_double(double x, double y){
 #define B(i,j) B[i][j]
 #define R(i,j) R[i][j]
 
-void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+void TMM(long Nnew, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
 	omp_set_num_threads(6);
 	///Parameter checking
+    N=Nnew;
 	if (!((N >= 1 && ts1_l1 > 0 && ts2_l1 > 0 && ts3_l1 > 0))) {
 		printf("The value of parameters are not valid.\n");
 		exit(-1);
 	}
 	//Memory Allocation
 	
-	#define S1(i,j,k) R(i,j) = (R(i,j))+((A(i,k))*(B(k,j)))
+	#define S1(i,j,k) R(i,j) = (R(i,j))+((A(i,k))*(B(k,j)))   
 	#define S2(i,j,k) R(i,j) = (A(i,k))*(B(k,j))
 	#define S0(i,j,i2) R(i,i2) = R(i,i2)
 	{
@@ -133,7 +153,11 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 		 {
 		 	for(ti2_l1=(ceild((ti1_l1-ts2_l1+1),(ts2_l1))) * (ts2_l1);ti2_l1 <= N;ti2_l1+=ts2_l1)
 		 	 {
-				#pragma omp parallel for
+                #pragma omp declare reduction (+:\
+                 float** : combine_R(omp_in,omp_out) ) \
+                initializer (omp_priv = initialize_R())
+
+                #pragma omp parallel for reduction(+:R)
 		 	 	for(ti3_l1=(ceild((ti1_l1-ts3_l1+1),(ts3_l1))) * (ts3_l1);ti3_l1 <= max(ti1_l1+ts1_l1-1,max(ti2_l1+ts2_l1-1,N));ti3_l1+=ts3_l1)
 		 	 	 {
 		 	 	 	{
@@ -254,6 +278,8 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 	
 	//Memory Free
 }
+
+
 
 //Memory Macros
 #undef A

--- a/parallelTests/ikj/out/secndLoop/TMM.c
+++ b/parallelTests/ikj/out/secndLoop/TMM.c
@@ -104,15 +104,36 @@ inline double __min_double(double x, double y){
 
 
 
+int N;
 
+float ** initialize_R ( ){
+    float * temp = malloc(sizeof(float)*(N+1)*(N+1));
+    float ** new_R = malloc(sizeof(float*)*(N+1));
+    for(int i = 0; i < N+1; i++){
+        new_R[i]=temp+(N+1)*i;
+        for(int j = 0; j < N+1; j++){
+            temp[i*(N+1)+j] = 0;
+        }
+    }
+    return new_R;
+}
+
+void combine_R( float ** omp_in, float ** omp_out){
+    for (int i = 0; i <= N; i++)
+        for (int j = i; j <= N; j++)
+            omp_out[i][j] += omp_in[i][j];
+    free(omp_in[0]);
+    free(omp_in);
+}
 
 //Memory Macros
 #define A(i,j) A[i][j]
 #define B(i,j) B[i][j]
 #define R(i,j) R[i][j]
 
-void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
-	omp_set_num_threads(6);
+void TMM(long newN, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+    N=newN;
+    omp_set_num_threads(6);
 	///Parameter checking
 	if (!((N >= 1 && ts1_l1 > 0 && ts2_l1 > 0 && ts3_l1 > 0))) {
 		printf("The value of parameters are not valid.\n");
@@ -131,7 +152,11 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 		int ti1_l1,ti2_l1,ti3_l1,c1,c2,c3;
 		for(ti1_l1=(ceild((-ts1_l1+2),(ts1_l1))) * (ts1_l1);ti1_l1 <= N-2;ti1_l1+=ts1_l1)
 		 {
-			#pragma omp parallel for
+			#pragma omp declare reduction (+:\
+                 float** : combine_R(omp_in,omp_out) ) \
+                initializer (omp_priv = initialize_R())
+
+            #pragma omp parallel for reduction(+:R)
 		 	for(ti2_l1=(ceild((ti1_l1-ts2_l1+1),(ts2_l1))) * (ts2_l1);ti2_l1 <= N;ti2_l1+=ts2_l1)
 		 	 {
 		 	 	for(ti3_l1=(ceild((min(ti1_l1,ti2_l1) + -ts3_l1+1),(ts3_l1))) * (ts3_l1);ti3_l1 <= N;ti3_l1+=ts3_l1)

--- a/parallelTests/ikj/out/secndLoop/envVars.sh
+++ b/parallelTests/ikj/out/secndLoop/envVars.sh
@@ -4,7 +4,7 @@ make clean
 make all
 
 export OMP_NUM_THREADS=1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100
 
 export OMP_NUM_THREADS=$1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100

--- a/parallelTests/jik/out/thirdLoop/TMM.c
+++ b/parallelTests/jik/out/thirdLoop/TMM.c
@@ -104,6 +104,27 @@ inline double __min_double(double x, double y){
 
 
 
+int N;
+
+float ** initialize_R ( ){
+    float * temp = malloc(sizeof(float)*(N+1)*(N+1));
+    float ** new_R = malloc(sizeof(float*)*(N+1));
+    for(int i = 0; i < N+1; i++){
+        new_R[i]=temp+(N+1)*i;
+        for(int j = 0; j < N+1; j++){
+            temp[i*(N+1)+j] = 0;
+        }
+    }
+    return new_R;
+}
+
+void combine_R( float ** omp_in, float ** omp_out){
+    for (int i = 0; i <= N; i++)
+        for (int j = i; j <= N; j++)
+            omp_out[i][j] += omp_in[i][j];
+    free(omp_in[0]);
+    free(omp_in);
+}
 
 
 //Memory Macros
@@ -111,7 +132,8 @@ inline double __min_double(double x, double y){
 #define B(i,j) B[i][j]
 #define R(i,j) R[i][j]
 
-void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+void TMM(long newN, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+	N=newN;
 	omp_set_num_threads(6);
 	///Parameter checking
 	if (!((N >= 1 && ts1_l1 > 0 && ts2_l1 > 0 && ts3_l1 > 0))) {
@@ -134,7 +156,11 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 		 {
 		 	for(ti2_l1=(ceild((-ts2_l1+2),(ts2_l1))) * (ts2_l1);ti2_l1 <= N;ti2_l1+=ts2_l1)
 		 	 {
-				#pragma omp parallel for
+				#pragma omp declare reduction (+:\
+                 float** : combine_R(omp_in,omp_out) ) \
+                initializer (omp_priv = initialize_R())
+
+                #pragma omp parallel for reduction(+:R)
 		 	 	for(ti3_l1=(ceild((min(ti1_l1,min(1,ti2_l1)) + -ts3_l1+1),(ts3_l1))) * (ts3_l1);ti3_l1 <= max(N,max(ti1_l1+ts1_l1-1,1));ti3_l1+=ts3_l1)
 		 	 	 {
 		 	 	 	{

--- a/parallelTests/jik/out/thirdLoop/envVars.sh
+++ b/parallelTests/jik/out/thirdLoop/envVars.sh
@@ -4,7 +4,7 @@ make clean
 make all
 
 export OMP_NUM_THREADS=1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100
 
 export OMP_NUM_THREADS=$1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100

--- a/parallelTests/jki/out/secndLoop/TMM.c
+++ b/parallelTests/jki/out/secndLoop/TMM.c
@@ -103,6 +103,27 @@ inline double __min_double(double x, double y){
 
 
 
+int N;
+
+float ** initialize_R ( ){
+    float * temp = malloc(sizeof(float)*(N+1)*(N+1));
+    float ** new_R = malloc(sizeof(float*)*(N+1));
+    for(int i = 0; i < N+1; i++){
+        new_R[i]=temp+(N+1)*i;
+        for(int j = 0; j < N+1; j++){
+            temp[i*(N+1)+j] = 0;
+        }
+    }
+    return new_R;
+}
+
+void combine_R( float ** omp_in, float ** omp_out){
+    for (int i = 0; i <= N; i++)
+        for (int j = i; j <= N; j++)
+            omp_out[i][j] += omp_in[i][j];
+    free(omp_in[0]);
+    free(omp_in);
+}
 
 
 
@@ -111,8 +132,9 @@ inline double __min_double(double x, double y){
 #define B(i,j) B[i][j]
 #define R(i,j) R[i][j]
 
-void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
-	omp_set_num_threads(6);
+void TMM(long newN, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+	N=newN;
+    omp_set_num_threads(6);
 	///Parameter checking
 	if (!((N >= 1 && ts1_l1 > 0 && ts2_l1 > 0 && ts3_l1 > 0))) {
 		printf("The value of parameters are not valid.\n");
@@ -131,7 +153,11 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 		int ti1_l1,ti2_l1,ti3_l1,c1,c2,c3;
 		for(ti1_l1=(ceild((-ts1_l1+2),(ts1_l1))) * (ts1_l1);ti1_l1 <= N;ti1_l1+=ts1_l1)
 		 {
-			#pragma omp parallel for
+			#pragma omp declare reduction (+:\
+                 float** : combine_R(omp_in,omp_out) ) \
+                initializer (omp_priv = initialize_R())
+
+            #pragma omp parallel for reduction(+:R)
 		 	for(ti2_l1=(ceild((-ts2_l1+2),(ts2_l1))) * (ts2_l1);ti2_l1 <= N;ti2_l1+=ts2_l1)
 		 	 {
 		 	 	for(ti3_l1=(ceild((min(1,ti1_l1) + -ts3_l1+1),(ts3_l1))) * (ts3_l1);ti3_l1 <= max(N,max(1,ti2_l1+ts2_l1-1));ti3_l1+=ts3_l1)

--- a/parallelTests/jki/out/secndLoop/envVars.sh
+++ b/parallelTests/jki/out/secndLoop/envVars.sh
@@ -4,7 +4,7 @@ make clean
 make all
 
 export OMP_NUM_THREADS=1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100
 
 export OMP_NUM_THREADS=$1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100

--- a/parallelTests/kij/out/firstLoop/TMM.c
+++ b/parallelTests/kij/out/firstLoop/TMM.c
@@ -101,6 +101,27 @@ inline double __min_double(double x, double y){
 }
 
 
+int N;
+
+float ** initialize_R ( ){
+    float * temp = malloc(sizeof(float)*(N+1)*(N+1));
+    float ** new_R = malloc(sizeof(float*)*(N+1));
+    for(int i = 0; i < N+1; i++){
+        new_R[i]=temp+(N+1)*i;
+        for(int j = 0; j < N+1; j++){
+            temp[i*(N+1)+j] = 0;
+        }
+    }
+    return new_R;
+}
+
+void combine_R( float ** omp_in, float ** omp_out){
+    for (int i = 0; i <= N; i++)
+        for (int j = i; j <= N; j++)
+            omp_out[i][j] += omp_in[i][j];
+    free(omp_in[0]);
+    free(omp_in);
+}
 
 
 
@@ -111,8 +132,9 @@ inline double __min_double(double x, double y){
 #define B(i,j) B[i][j]
 #define R(i,j) R[i][j]
 
-void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
-	omp_set_num_threads(6);
+void TMM(long newN, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, float** R){
+	N=newN;
+    omp_set_num_threads(6);
 	///Parameter checking
 	if (!((N >= 1 && ts1_l1 > 0 && ts2_l1 > 0 && ts3_l1 > 0))) {
 		printf("The value of parameters are not valid.\n");
@@ -129,7 +151,11 @@ void TMM(long N, long ts1_l1, long ts2_l1, long ts3_l1, float** A, float** B, fl
 		//{i,j,k|j==i && i>=1 && N>=k && k>=i && k>=1 && N>=i && N>=1}
 		//{i,j,i2|j==N && i2>=1 && N>=i2 && i>=1 && i2>=i && N>=1}
 		int ti1_l1,ti2_l1,ti3_l1,c1,c2,c3;
-		#pragma omp parallel for
+		#pragma omp declare reduction (+:\
+                 float** : combine_R(omp_in,omp_out) ) \
+                initializer (omp_priv = initialize_R())
+
+            #pragma omp parallel for reduction(+:R)
 		for(ti1_l1=(ceild((-ts1_l1+2),(ts1_l1))) * (ts1_l1);ti1_l1 <= N;ti1_l1+=ts1_l1)
 		 {
 		 	for(ti2_l1=(ceild((-ts2_l1+2),(ts2_l1))) * (ts2_l1);ti2_l1 <= N;ti2_l1+=ts2_l1)

--- a/parallelTests/kij/out/firstLoop/envVars.sh
+++ b/parallelTests/kij/out/firstLoop/envVars.sh
@@ -4,7 +4,7 @@ make clean
 make all
 
 export OMP_NUM_THREADS=1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100
 
 export OMP_NUM_THREADS=$1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100

--- a/parallelTests/kji/out/firstLoop/envVars.sh
+++ b/parallelTests/kji/out/firstLoop/envVars.sh
@@ -4,7 +4,7 @@ make clean
 make all
 
 export OMP_NUM_THREADS=1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100
 
 export OMP_NUM_THREADS=$1
-./TMM.verify-rand 5000 100 100 100
+./TMM.verify-rand 2000 100 100 100


### PR DESCRIPTION
These work, however they work by copying the entire R array many times and then adding the entire R array to itself multiple times. This means it is incredibly slow and should not ever really be used, but they do work. We measured a run time of 3 minutes on IJK-K with inputs of 5000 100 100 100.

This would be easier if TMM.c used block major format (we would not need to copy the whole thing).